### PR TITLE
Set correct path to example config in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Clone this repository and run from a terminal
 ```
 or `pip install -e .` if you want to install it in developer mode. This will install the module `iop4lib` and the `iop4` command, and the `iop4site` project.
 
-After installation, take a look at the example configuration file (`config/config.example.yaml`), set the appropriate variables (path to the database, data directory, astrometry index files path, credentials, etc) and rename it to `iop4lib/config.yaml`.
+After installation, take a look at the example configuration file (`config/config.example.yaml`), set the appropriate variables (path to the database, data directory, astrometry index files path, credentials, etc) and rename it to `config/config.yaml`.
 
 If no previous database exists, make sure to create it. You can do it automatically from the `iop4site/` directory by using
 ```bash


### PR DESCRIPTION
Right now it points to a non-existing file. Also corrected typos