### PR TITLE
Use html link for badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ To build and show the documentation, run
 
 ## Contribute
 
-Status (main branch) <a href="https://github.com/juanep97/iop4/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/juanep97/iop4/actions/workflows/ci.yml/badge.svg"/></a>
+Status (main branch) 
+
+<a href="https://github.com/juanep97/iop4/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/juanep97/iop4/actions/workflows/ci.yml/badge.svg"/></a>
 
 You are welcome to contribute to IOP4. Fork and create a PR!


### PR DESCRIPTION
This way it is shown correctly both in github page and sphinx html output for the documentation.