### PR TITLE
Add MANIFEST.in file for packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+prune iop4lib/_dev_version
+prune .github
+prune .gitignore


### PR DESCRIPTION
excluding the `_dev_version` and github-related folders.

This tries to solve the appearance of the warning:
```
/tmp/build-env-38jhk5t9/lib/python3.10/site-packages/setuptools/command/build_py.py:207: _Warning: Package 'iop4lib._dev_version' is absent from the `packages` configuration.
```
when building the package.