### PR TITLE
Add a time out for actions in CI and cancel previous jobs for the same PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       - '**'
   pull_request:
 
+concurrency:
+  # cancel previous runs of the same workflow for the same PR when new commits are pushed
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   NUMBA_NUM_THREADS: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
 
 
   tests:
+    timeout-minutes: 60
     strategy:
       matrix:
         include:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<a href="https://github.com/juanep97/iop4/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/juanep97/iop4/actions/workflows/ci.yml/badge.svg"/></a>
+<a href="https://zenodo.org/doi/10.5281/zenodo.10222722"><img src="https://zenodo.org/badge/636786270.svg" alt="DOI"></a>
 
 **IOP4** is a complete rewrite of IOP3, a pipeline to work with **photometry** and **polarimetry** of **optical data** from [CAHA](https://www.caha.es/es/) and [OSN](https://www.osn.iaa.csic.es/) observatories. It is built to ease debugging and inspection of data.
 
@@ -142,9 +144,5 @@ To build and show the documentation, run
 ````
 
 ## Contribute
-
-Status (main branch) 
-
-<a href="https://github.com/juanep97/iop4/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/juanep97/iop4/actions/workflows/ci.yml/badge.svg"/></a>
 
 You are welcome to contribute to IOP4. Fork and create a PR!


### PR DESCRIPTION
Tests should pass in less than 1 hour, if it keeps running more it is because it is stuck (#29).

When new commits are added to a branch in a PR, previous ones should be discarded. Since they take some time to run it creates a mess of messages arriving at different times.