### PR TITLE
Bump setuptools_scm version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=65", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=65", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
I do not know if this will help with the last warning reported in #42. Just in case, forcing the use of the latest version.

EDIT: The message is still there...

That warning during the wheel build seems to be harmless though (https://github.com/search?q=repo%3Apypa%2Fsetuptools_scm+listing+git+files+failed&type=issues)