### PR TITLE
Fix dipol quads, iop4 command

### DIFF
--- a/iop4lib/instruments/dipol.py
+++ b/iop4lib/instruments/dipol.py
@@ -620,6 +620,10 @@ class DIPOL(Instrument):
         quads_1 = np.array(list(itertools.combinations(sets_L[0], 4)))
         quads_2 = np.array(list(itertools.combinations(sets_L[1], 4)))
 
+        if len(quads_1) == 0 or len(quads_2) == 0:
+            logger.error(f"No quads found in {redf_pol} and {redf_phot}, returning success = False.")
+            return BuildWCSResult(success=False)
+        
         from iop4lib.utils.quadmatching import hash_ish, distance, order, qorder_ish, find_linear_transformation
         hash_func, qorder = hash_ish, qorder_ish
 

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -361,12 +361,10 @@ def main():
             for telname, filelocs in group_filelocs_by_telescope(filelocs_missing).items():
                 Telescope.by_name(telname).download_rawfits(filelocs)
 
-            for fileloc in filelocs_missing:
-                rawfit = RawFit.create(fileloc=fileloc)
-
         if len(filelocs_to_process) > 0:
             logger.info("Processing files.")
-            pass
+            for fileloc in filelocs_to_process:
+                rawfit = RawFit.create(fileloc=fileloc)
 
     else:
         logger.info("Invoked with --list-files-only")


### PR DESCRIPTION
Changes:
 - iop4.py command was ignoring filelocs_to_process, which is supposed to be the selected file list by the command line options.
 - Fix dipol quads not handling the case where no quads are found in the image. This was causing an exception and therefore aborting the reduction of that specific file, instead of just returning success=False and continuing with another attempt.