### PR TITLE
improve iop4 cmd config options and log viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ An utility script, `iop4site/resetdb.py`, is provided which will completely rese
 ### As A Program
 The pipeline script `iop4` can be invoked as
 ```bash
-    $ iop4 -l tel1/yymmdd tel2/yymmdd
+    $ iop4 --epoch-list tel1/yymmdd tel2/yymmdd
 ```
 to download and reduce the epoch `yymmdd` from telescopes `tel1` and `tel2` respectively. For example: `iop4 -l T090/230430`.
 
@@ -131,9 +131,9 @@ iop4conf = iop4lib.Config(config_db=True, gonogui=False, jupytermode=True)
 ```
 
 ### Tips
-You can get an IPython interactive terminal after running iop4 using the `-i` option as
+You can get an IPython interactive terminal after running iop4 using the `-i` option. You can override any config option using the `-o` option, e.g.:
 ```bash
-    $ iop4 -i -l T090/230313 T090/230317 T090/230319
+    $ iop4 -i -o nprocs=20 -o log_file=test.log --epoch-list T090/230313 T090/230317
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ iop4conf = iop4lib.Config(config_db=True, gonogui=False, jupytermode=True)
 ### Tips
 You can get an IPython interactive terminal after running iop4 using the `-i` option. You can override any config option using the `-o` option, e.g.:
 ```bash
-    $ iop4 -i -o nprocs=20 -o log_file=test.log --epoch-list T090/230313 T090/230317
+    $ iop4 -i -o nthreads=20 -o log_file=test.log --epoch-list T090/230313 T090/230317
 ```
 
 ## Documentation

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -9,9 +9,9 @@ datadir: ~/.iop4data/ # <str> Path to iop4data data folder.
 set_rawdata_readonly: False # <bool> True / False (sets raw fits file to readonly when downloading them or creating a RawFit object).
 db_path: ~/.iop4data/iop4.db # Path to iop4 sqlite database file.
 astrometry_cache_path: ~/.astrometry_cache/ # <tr> Path to store the astromery index files.
-nprocs: 4 # <int> Number of threads / processes to use (e.g. 4).
+nthreads: 4 # <int> Number of threads / processes to use (e.g. 4).
 astrometry_timeout: 20 # <int> Timeout in minutes for astrometry solving.
-astrometry_allsky_allow: false # <bool> Whether to allow all sky searches in the astrometry.net solver. If there are many all-sky images and nprocs is too high, it might cause
+astrometry_allsky_allow: false # <bool> Whether to allow all sky searches in the astrometry.net solver. If there are many all-sky images and nthreads is too high, it might cause
 # very high memory consumption.
 astrometry_allsky_septhreshold: 25 # <int> Threshold of detected poinint mismatch to trigger an all-sky search.
 

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -9,9 +9,9 @@ datadir: ~/.iop4data/ # <str> Path to iop4data data folder.
 set_rawdata_readonly: False # <bool> True / False (sets raw fits file to readonly when downloading them or creating a RawFit object).
 db_path: ~/.iop4data/iop4.db # Path to iop4 sqlite database file.
 astrometry_cache_path: ~/.astrometry_cache/ # <tr> Path to store the astromery index files.
-max_concurrent_threads: 4 # <int> Number of threads / processes to use (e.g. 4).
+nprocs: 4 # <int> Number of threads / processes to use (e.g. 4).
 astrometry_timeout: 20 # <int> Timeout in minutes for astrometry solving.
-astrometry_allsky_allow: false # <bool> Whether to allow all sky searches in the astrometry.net solver. If there are many all-sky images and max_concurrent_threads is too high, it might cause
+astrometry_allsky_allow: false # <bool> Whether to allow all sky searches in the astrometry.net solver. If there are many all-sky images and nprocs is too high, it might cause
 # very high memory consumption.
 astrometry_allsky_septhreshold: 25 # <int> Threshold of detected poinint mismatch to trigger an all-sky search.
 
@@ -25,7 +25,7 @@ mplt_default_dpi: 100 # <int> dpi for matplotlib (e.g. 100)
 ### LOGGING ###
 ###############
 
-log_fname: ~/.iop4data/iop4.log # </path/to/iop4.log>
+log_file: ~/.iop4data/logs/iop4.log # <str> Path to log file. Use $date to automatically use current date 'YYYY-MM-DD' in the path.
 log_date_format: '%Y-%m-%d %H:%M:%S' # <log date format>
 log_format: '%(asctime)s - %(name)s [%(filename)s:%(lineno)d] - %(levelname)s - %(message)s' # <log format> You can also add '%(process)d (%(proc_memory)s)' to the format to show pid and memory usage per process.
 log_level: 20 # <int>. Possible values are: 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL).

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -25,7 +25,7 @@ mplt_default_dpi: 100 # <int> dpi for matplotlib (e.g. 100)
 ### LOGGING ###
 ###############
 
-log_file: ~/.iop4data/logs/iop4.log # <str> Path to log file. Use $date to automatically use current date 'YYYY-MM-DD' in the path.
+log_file: ~/.iop4data/logs/iop4.log # <str> Path to log file.
 log_date_format: '%Y-%m-%d %H:%M:%S' # <log date format>
 log_format: '%(asctime)s - %(name)s [%(filename)s:%(lineno)d] - %(levelname)s - %(message)s' # <log format> You can also add '%(process)d (%(proc_memory)s)' to the format to show pid and memory usage per process.
 log_level: 20 # <int>. Possible values are: 10 (DEBUG), 20 (INFO), 30 (WARNING), 40 (ERROR), 50 (CRITICAL).

--- a/iop4api/static/iop4api/base.css
+++ b/iop4api/static/iop4api/base.css
@@ -438,8 +438,6 @@ form label {
 }
 
 .pipeline-log-entry {
-    line-height: 12px !important;
-    padding: 2px !important;
     font-size: 10px !important;
 }
 .pipeline-log-entry .highlight {

--- a/iop4api/static/iop4api/gui.js
+++ b/iop4api/static/iop4api/gui.js
@@ -690,45 +690,25 @@ function load_catalog() {
 /********** LOGS*** **********/
 /*****************************/
 
-function load_pipeline_log() {
-    const decoder = new TextDecoder('utf-8');
-    
-    let output = '';
-
-    fetch('/iop4/api/log/')
-        .then(response => {
-            vueApp.$data.pipeline_log.isLoaded = false;
-            const reader = response.body.getReader();
-            return new ReadableStream({
-                start(controller) {
-                function push() {
-                    reader.read().then(({ done, value }) => {
-                        if (done) {
-                            controller.close();
-                            vueApp.$data.pipeline_log.isLoaded = true;
-                            vueApp.$data.pipeline_log.data = output;
-                            show_pipeline_log();
-                            return;
-                        }
-                        output += decoder.decode(value);
-                        push();
-                    });
-                }
-                push();
-            }
-        });
-    });
-}
-
 function extractTextFromHTML(html) {
+    /* This function returns the text content of the given html */
     let parser = new DOMParser();
     let doc = parser.parseFromString(html, 'text/html');
     return doc.body.textContent || "";
 }
 
-highlight_parser = new DOMParser();
 
 function highlightTextInHTML(html, re_expr) {
+    /* 
+        This function looks only inside the text nodes of the given html, and highlights the given pattern by substituting the text with a span with class highlight 
+        The re_expr pattern should take care not to break html entities, e.g.
+            const re_expr = new RegExp(`(?<!&#?[a-zA-Z]*)${searchstring}(?![a-zA-Z]*;)`, 'gi');
+        will make sure to match the search string only if it is not part of an html entity. 
+        This is needed because when the value of the text noded is extracted, html entities get 
+        transformed to their unicode representation, e.g. &lt; becomes < and &gt; becomes >. Therefore not to break the html these need to be
+        transformed back to their html entity representation, e.g. < replaced by &lt; and > replaced by &gt;. Then searching for 'g' would 
+        break the entity if it is not excluded from the search.
+    */
     let parser = new DOMParser();
     let doc = parser.parseFromString(html, 'text/html');
 
@@ -737,7 +717,10 @@ function highlightTextInHTML(html, re_expr) {
             const matches = node.nodeValue.match(re_expr);
             if (matches) {
                 const span = document.createElement('span');
-                span.innerHTML = node.nodeValue.replaceAll(re_expr, '<span class="highlight">$&</span>');
+
+                // span.innerHTML = node.nodeValue.replaceAll(re_expr, '<span class="highlight">$&</span>');
+                span.innerHTML = node.nodeValue.replace('<','&lt;').replace('>','&gt;').replaceAll(re_expr, '<span class="highlight">$&</span>');
+
                 node.parentNode.replaceChild(span, node);
             }
         } else if (node.nodeType === 1) { // Node.ELEMENT_NODE
@@ -749,36 +732,116 @@ function highlightTextInHTML(html, re_expr) {
     return doc.body.innerHTML;
 }
 
-function highlightTextInHTML2(html, re_expr) {
-    return html.replaceAll(re_expr, function(match) {
-        return `<span class="highlight">${match}</span>`;
-    });
-}
+async function load_pipeline_log() {
 
-function show_pipeline_log() {
 
-    console.log("vueApp.$data.pipeline_log_options", vueApp.$data.pipeline_log_options)
+    this.filter_text = ''; // clear the filter text (it would not make sense to push to the filtered array below otherwise)
 
-    // Filter the log lines
-    vueApp.$data.pipeline_log.items = vueApp.$data.pipeline_log.data.split('\n').filter((txt) => {
-        // if the filter text is not empty, hide lines that do not contain it
-        if (!!(vueApp.$data.pipeline_log_options.filter_text) && (vueApp.$data.pipeline_log_options.filter_text.length > 0)) {
-            if (!extractTextFromHTML(txt).toUpperCase().includes(vueApp.$data.pipeline_log_options.filter_text.toUpperCase())) { return false; }
-        }
-        // show only lines of the selected logging levels
-        if ((txt.includes('ERROR')) && (vueApp.$data.pipeline_log_options.errors)){ return true; }
-        if ((txt.includes('WARNING')) && (vueApp.$data.pipeline_log_options.warnings)){ return true; }
-        if ((txt.includes('INFO')) && (vueApp.$data.pipeline_log_options.info)){ return true; }
-        if ((txt.includes('DEBUG')) && (vueApp.$data.pipeline_log_options.debug)){ return true; }
-        return false
-    });
-    
-    // Highlight the searched text
-    if ((vueApp.$data.pipeline_log_options.filter_text != null) && (vueApp.$data.pipeline_log_options.filter_text != '' && vueApp.$data.pipeline_log_options.filter_text.length > 0)) {
-        re_expr = new RegExp(vueApp.$data.pipeline_log_options.filter_text, 'gi');
-        for (let i = 0; i < vueApp.$data.pipeline_log.items.length; i++) {
-            vueApp.$data.pipeline_log.items[i] = highlightTextInHTML(vueApp.$data.pipeline_log.items[i], re_expr);
-        }
+    console.log("Loading pipeline log...");
+
+    const decoder = new TextDecoder('utf-8');
+    const response = await fetch('/iop4/api/log/');
+    let data = ''
+    for await (const chunk of response.body) {
+        data += decoder.decode(chunk);
+        new_items = data.split('\n').slice(vueApp.$data.pipeline_log.items.length,-1);
+        vueApp.$data.pipeline_log.items.push(...new_items);
+        // initially put them also in the filtered array so the log appears as they are received
+        vueApp.$data.pipeline_log.items_filtered.push(...new_items.filter(is_log_visible)); 
     }
 
+    console.log("Pipeline log loaded!");
 }
+
+function is_log_visible(txt) {
+    /* whether the given log line should be visible or not */
+    
+    // show only lines of the selected logging levels
+    if ((txt.includes('ERROR')) && (!vueApp.$data.pipeline_log_options.errors)){ return false; }
+    if ((txt.includes('WARNING')) && (!vueApp.$data.pipeline_log_options.warnings)){ return false; }
+    if ((txt.includes('INFO')) && (!vueApp.$data.pipeline_log_options.info)){ return false; }
+    if ((txt.includes('DEBUG')) && (!vueApp.$data.pipeline_log_options.debug)){ return false; }
+    if (!(txt.includes('ERROR') || txt.includes('WARNING') || txt.includes('INFO') || txt.includes('DEBUG'))) { return false; }
+
+    // if the filter text is not empty, hide lines that do not contain it
+    if (!!(vueApp.$data.pipeline_log_options.filter_text) && (vueApp.$data.pipeline_log_options.filter_text.length > 0)) {
+        if (!extractTextFromHTML(txt).toUpperCase().includes(vueApp.$data.pipeline_log_options.filter_text.toUpperCase())) { return false; }
+    }
+
+    return true;
+}
+
+
+/* The following code implements the filtering (by is_log_visible) of the pipeline log, and its formatting (by highlightTextInHTML) in a way that
+the page does not freeze when the user types in the filter text input. 
+It does it by:
+    - using a debounce function that waits for the user to stop typing for a given amount of time (debounceDelay) before processing the log items.
+    - canceling the processing if a new filtering request has been made. 
+    - processing is done in chunks of 100 items, and the next chunk is scheduled to be processed after the current one has finished.
+    - using async functions.
+This solution is obviously a bit slower but it is much more responsive.
+*/
+
+let debounceTimer;
+const debounceDelay = 10; // milliseconds
+let currentFilterTimestamp = 0;
+
+async function format_pipeline_logs() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+        processLogItems();
+    }, debounceDelay);
+}
+
+async function processLogItems() {
+
+    vueApp.$data.pipeline_log.filter_in_progress = true;
+
+    const startTime = Date.now();
+    currentFilterTimestamp = startTime;
+    console.log("Filtering pipeline log");
+
+    // Clear the existing array
+    vueApp.$data.pipeline_log.items_filtered = [];
+
+    const processChunk = async (start, chunkSize) => {
+        for (let i = start; i < start + chunkSize && i < vueApp.$data.pipeline_log.items.length; i++) {
+            const txt = vueApp.$data.pipeline_log.items[i];
+
+            // Check if a new filtering request has been made
+            if (currentFilterTimestamp !== startTime) {
+                console.log("Filtering cancelled due to new input");
+                return; // Exit the loop early
+            }
+
+            // Check if log is visible
+            if (is_log_visible(txt)) {
+                let formattedText = txt;
+
+                // Check for highlight condition
+                if (vueApp.$data.pipeline_log_options.filter_text) {
+                    // const re_expr = new RegExp(vueApp.$data.pipeline_log_options.filter_text, 'gi');
+                    const re_expr = new RegExp(`(?<!&#?[a-zA-Z]*)${vueApp.$data.pipeline_log_options.filter_text}(?![a-zA-Z]*;)`, 'gi');
+                    formattedText = highlightTextInHTML(txt, re_expr);
+                }
+
+                // Push individually
+                vueApp.$data.pipeline_log.items_filtered.push(formattedText);
+            }
+        }
+
+        if (start + chunkSize < vueApp.$data.pipeline_log.items.length) {
+            // Schedule next chunk
+            setTimeout(() => processChunk(start + chunkSize, chunkSize), 0);
+        } else if (currentFilterTimestamp === startTime) {
+            console.log("Pipeline log filtered");
+            vueApp.$data.pipeline_log.filter_in_progress = false;
+        }
+    };
+
+    const chunkSize = 100; // Adjust based on performance
+    processChunk(0, chunkSize);
+
+}
+
+/*****************************/

--- a/iop4api/static/iop4api/gui.js
+++ b/iop4api/static/iop4api/gui.js
@@ -734,15 +734,21 @@ function highlightTextInHTML(html, re_expr) {
 
 async function load_pipeline_log() {
 
+    this.pipeline_log_options.filter_text = ''; // clear the filter text (it would not make sense to push to the filtered array below otherwise)
 
-    this.filter_text = ''; // clear the filter text (it would not make sense to push to the filtered array below otherwise)
+    console.log(`Loading pipeline log for ${this.log_file}`);
 
-    console.log("Loading pipeline log...");
-
+    const log_file = this.log_file;
     const decoder = new TextDecoder('utf-8');
-    const response = await fetch('/iop4/api/log/');
+    const response = await fetch(`/iop4/api/log/?log_file=${log_file}`);
+
     let data = ''
     for await (const chunk of response.body) {
+        if (log_file !== this.log_file) {
+            console.log("Pipeline log loading cancelled due to new input");
+            return; // Exit the loop early
+        }
+
         data += decoder.decode(chunk);
         new_items = data.split('\n').slice(vueApp.$data.pipeline_log.items.length,-1);
         vueApp.$data.pipeline_log.items.push(...new_items);

--- a/iop4api/templates/iop4api/index.html
+++ b/iop4api/templates/iop4api/index.html
@@ -96,7 +96,7 @@
     <script src="https://cdn.jsdelivr.net/npm/quasar@2.12.5/dist/quasar.umd.prod.js"></script>
     
     <script>
-
+        const log_files = JSON.parse('{{ log_files | escapejs }}');
         const tab_tree = JSON.parse('{{ tab_tree | escapejs }}');
         const { ref } = Vue
         
@@ -133,7 +133,13 @@
                     input_astrosource: '',
                     // logs
                     pipeline_log: {'isLoaded': false, 'items': null, 'items_filtered': null, 'filter_in_progress': false},
-                    pipeline_log_options: {'errors':true, 'warnings':true, 'info':true, 'debug':false, 'filter_text': null},
+                    pipeline_log_options: {'errors':true, 
+                                           'warnings':true, 
+                                           'info':true, 
+                                           'debug':false, 
+                                           'filter_text': null,},
+                    log_file: 'iop4.log',
+                    log_files: log_files,
                 }
             },
             computed: {
@@ -252,7 +258,7 @@
                             if (this.pipeline_log.items == null && newVal === 'logs') {
                                 this.pipeline_log.items = [];
                                 this.pipeline_log.items_filtered = [];
-                                load_pipeline_log();
+                                load_pipeline_log.bind(this)();
                             }
                         }
                     },
@@ -265,6 +271,14 @@
                         format_pipeline_logs();
                     },
                     deep: true
+                },
+                log_file: {
+                    handler(newValue, oldValue) {
+                        console.log('log_file changed to ' + newValue);
+                        this.pipeline_log.items = [];
+                        this.pipeline_log.items_filtered = [];
+                        load_pipeline_log.bind(this)();
+                    },
                 },
                 // data table filters
                 DataTableFilters: {

--- a/iop4api/templates/iop4api/index.html
+++ b/iop4api/templates/iop4api/index.html
@@ -132,7 +132,7 @@
                     // query
                     input_astrosource: '',
                     // logs
-                    pipeline_log: {'isLoaded': false, 'data': null, items:[]},
+                    pipeline_log: {'isLoaded': false, 'items': null, 'items_filtered': null, 'filter_in_progress': false},
                     pipeline_log_options: {'errors':true, 'warnings':true, 'info':true, 'debug':false, 'filter_text': null},
                 }
             },
@@ -249,7 +249,9 @@
                             if (this.catalog == null && newVal === 'catalog') {
                                 load_catalog();
                             }
-                            if (this.pipeline_log.data == null && newVal === 'logs') {
+                            if (this.pipeline_log.items == null && newVal === 'logs') {
+                                this.pipeline_log.items = [];
+                                this.pipeline_log.items_filtered = [];
                                 load_pipeline_log();
                             }
                         }
@@ -260,15 +262,7 @@
                 // log viewer gui
                 pipeline_log_options: {
                     handler(newValue, oldValue) {
-                        if (this.pipeline_log.isLoaded) {
-                            // filter on input with:
-                            //show_pipeline_log();
-                            // but this can be slow if the log is large and there's only 1 or 2 chars written
-                            // better filter on enter (implemented on the @change)
-                            // but if filter options are changed, we should trigger filter (done in @update:selected on the q-chips)
-                            // if the update is done here, remove those @events
-                        }
-                        this.pipeline_log_options.filter_timeout = null;
+                        format_pipeline_logs();
                     },
                     deep: true
                 },
@@ -382,7 +376,9 @@
                 toggle_flag,
                 set_flag,
                 // logs,
-                show_pipeline_log,
+                load_pipeline_log,
+                is_log_visible,
+                format_pipeline_logs,
                 // to format floats to give precision or return nan
                 formatFloat(value, precision) {
                     if (value === null || isNaN(Number(value))) {
@@ -400,8 +396,6 @@
                 });
             }
         }).use(Quasar).mount('#app')
-
-        //Quasar.iconSet.set(Quasar.iconSet.materialIconsOutlined);
 
     </script>
 

--- a/iop4api/templates/iop4api/logs.html
+++ b/iop4api/templates/iop4api/logs.html
@@ -28,7 +28,12 @@
         >
             <q-card>
                 <q-card-section style="padding: 8px 16px 0 16px;">
-                    <div>
+                    <div class="row items-center q-gutter-sm">
+                        <q-select
+                            v-model="log_file"
+                            :options="log_files"
+                            dense
+                        ></q-select>
                         <q-chip @update:selected="() => $nextTick(format_pipeline_logs)" v-model:selected="pipeline_log_options.errors" color="red" text-color="white" icon="error" :outline="!pipeline_log_options.errors">
                             errors
                         </q-chip>

--- a/iop4api/templates/iop4api/logs.html
+++ b/iop4api/templates/iop4api/logs.html
@@ -29,24 +29,29 @@
             <q-card>
                 <q-card-section style="padding: 8px 16px 0 16px;">
                     <div>
-                        <q-chip @update:selected="() => $nextTick(show_pipeline_log)" v-model:selected="pipeline_log_options.errors" color="red" text-color="white" icon="error" :outline="!pipeline_log_options.errors">
+                        <q-chip @update:selected="() => $nextTick(format_pipeline_logs)" v-model:selected="pipeline_log_options.errors" color="red" text-color="white" icon="error" :outline="!pipeline_log_options.errors">
                             errors
                         </q-chip>
-                        <q-chip @update:selected="() => $nextTick(show_pipeline_log)" v-model:selected="pipeline_log_options.warnings" color="orange" text-color="white" icon="warning" :outline="!pipeline_log_options.warnings">
+                        <q-chip @update:selected="() => $nextTick(format_pipeline_logs)" v-model:selected="pipeline_log_options.warnings" color="orange" text-color="white" icon="warning" :outline="!pipeline_log_options.warnings">
                             warning
                         </q-chip>
-                        <q-chip @update:selected="() => $nextTick(show_pipeline_log)" v-model:selected="pipeline_log_options.info" color="darkgray" text-color="black" icon="info" :outline="!pipeline_log_options.info">
+                        <q-chip @update:selected="() => $nextTick(format_pipeline_logs)" v-model:selected="pipeline_log_options.info" color="darkgray" text-color="black" icon="info" :outline="!pipeline_log_options.info">
                             info
                         </q-chip>
-                        <q-chip @update:selected="() => $nextTick(show_pipeline_log)" v-model:selected="pipeline_log_options.debug" color="green" text-color="white" icon="code" :outline="!pipeline_log_options.debug">
+                        <q-chip @update:selected="() => $nextTick(format_pipeline_logs)" v-model:selected="pipeline_log_options.debug" color="green" text-color="white" icon="code" :outline="!pipeline_log_options.debug">
                             debug
                         </q-chip>
-                        <!-- <input type="text" v-model="pipeline_log_options.filter_text" placeholder="filter text" class="q-chip row inline no-wrap items-center text-black q-chip--colored q-chip--outline" style="outline: none;"> -->
-                        <input type="text" @change="show_pipeline_log()" v-model="pipeline_log_options.filter_text" placeholder="filter text (+ Enter)" class="q-chip row inline no-wrap items-center text-black q-chip--colored q-chip--outline" style="outline: none;">
+                        <input type="text" @change="format_pipeline_logs();" v-model="pipeline_log_options.filter_text" placeholder="filter text (+ Enter)" class="q-chip row inline no-wrap items-center text-black q-chip--colored q-chip--outline" style="outline: none;">
+                        <q-spinner
+                            v-show="pipeline_log.filter_in_progress"
+                            color="primary"
+                            size="1em"
+                            :thickness="10"
+                        ></q-spinner>
                     </div>
                     <div id="pipeline-logs-tab-content">
                         <div id="log-file-content">
-                            <q-virtual-scroll :items="pipeline_log.items" style="height: 100%;" virtual-scroll-item-size="14" separator v-slot="{ item, index }">
+                            <q-virtual-scroll :items="pipeline_log.items_filtered" style="height: 100%;" virtual-scroll-item-size="14" separator v-slot="{ item, index }">
                                 <q-item :key="index" dense class="pipeline-log-entry">
                                     <q-item-section  class="pipeline-log-entry">
                                         <q-item-label class="pipeline-log-entry">

--- a/iop4api/views/index.py
+++ b/iop4api/views/index.py
@@ -15,6 +15,7 @@ from iop4lib.enums import SRCTYPES
 import json
 import os
 import subprocess
+from pathlib import Path
 
 #logging
 import logging
@@ -52,5 +53,8 @@ def index(request, tabs=None):
     context['git_commit_hash'] = GIT_COMMIT_HASH
     context['git_branch'] = GIT_BRANCH
     context['git_describe'] = GIT_DESCRIBE
+
+    # add the available log files
+    context['log_files'] = json.dumps([os.path.basename(f) for f in os.listdir(Path(iop4conf.datadir) / "logs") if f.endswith(".log")])
 
     return render(request, 'iop4api/index.html', context)

--- a/iop4api/views/log.py
+++ b/iop4api/views/log.py
@@ -13,7 +13,6 @@ from django.contrib.admin.views.decorators import staff_member_required
 import coloredlogs
 import coloredlogs.converter
 from pathlib import Path
-import os
 
 #logging
 import logging

--- a/iop4api/views/log.py
+++ b/iop4api/views/log.py
@@ -12,19 +12,29 @@ from django.contrib.admin.views.decorators import staff_member_required
 # other imports
 import coloredlogs
 import coloredlogs.converter
+from pathlib import Path
+import os
 
 #logging
 import logging
 logger = logging.getLogger(__name__)
 
 
-def _log_file_generator():
-    with open(iop4conf.log_fname, "r") as f:
-        for line in f:
-            yield coloredlogs.converter.convert(line)
+def get_log_file_generator(fpath):
+    def _log_file_generator():
+        with open(fpath, "r") as f:
+            for line in f:
+                yield coloredlogs.converter.convert(line)
+    return _log_file_generator()
 
 @staff_member_required
 @permission_required(["iop4api.view_photpolresult", "iop4api.view_astrosource"]) 
 def log(request):
     r"""Staff memember required. Since the log file can be very large, we use a generator to stream it to the client."""
-    return StreamingHttpResponse(_log_file_generator(), content_type="text/plain")
+
+    if request.GET.get("log_file", None) is None:
+        fpath = iop4conf.log_file
+    else:
+        fpath = str(Path(iop4conf.datadir) / "logs" / request.GET.get("log_file"))
+
+    return StreamingHttpResponse(get_log_file_generator(fpath), content_type="text/plain")

--- a/iop4api/views/log.py
+++ b/iop4api/views/log.py
@@ -30,7 +30,7 @@ def get_log_file_generator(fpath):
 @staff_member_required
 @permission_required(["iop4api.view_photpolresult", "iop4api.view_astrosource"]) 
 def log(request):
-    r"""Staff memember required. Since the log file can be very large, we use a generator to stream it to the client."""
+    r"""Staff member required. Since the log file can be very large, we use a generator to stream it to the client."""
 
     if request.GET.get("log_file", None) is None:
         fpath = iop4conf.log_file

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -127,7 +127,7 @@ class Config(dict):
         # Allow paths relative to home directory
 
         for k, v in self.items():
-            if (k in ['basedir', 'datadir', 'log_fname'] or 'path' in k) and v is not None: # config variables that are should have ~ expanded
+            if (k in ['basedir', 'datadir', 'log_file'] or 'path' in k) and v is not None: # config variables should have ~ expanded
                 setattr(self, k, str(pathlib.Path(v).expanduser()))
 
         # If data dir does not exist, create it

--- a/iop4lib/db/epoch.py
+++ b/iop4lib/db/epoch.py
@@ -418,7 +418,7 @@ class Epoch(models.Model):
         the BUILT_REDUCED flag) will be reduced, else all rawfits of this epoch of type LIGHT be 
         reduced.
 
-        If iop4conf.nprocs > 1, the reduction will be done in parallel processes.
+        If iop4conf.nthreads > 1, the reduction will be done in parallel processes.
         """
 
         Epoch.reduce_rawfits(self.rawfits.filter(imgtype=IMGTYPES.LIGHT), force_rebuild=force_rebuild, epoch=self)
@@ -434,7 +434,7 @@ class Epoch(models.Model):
         If force_rebuild is False, only rawfits that have not been reduced yet (that do not have 
         the BUILT_REDUCED flag) will be reduced, else all rawfits in the list will be reduced.
 
-        If iop4conf.nprocs > 1, the reduction will be done in parallel processes.
+        If iop4conf.nthreads > 1, the reduction will be done in parallel processes.
 
         Parameters
         ----------
@@ -462,7 +462,7 @@ class Epoch(models.Model):
     def reduce_reducedfits(reduced_L, epoch=None):
         """ Bulk reduces a list of ReducedFit in a multiprocessing pool. 
         
-        If iop4conf.nprocs > 1, the reduction will be done in parallel processes.
+        If iop4conf.nthreads > 1, the reduction will be done in parallel processes.
 
         Parameters
         ----------
@@ -478,7 +478,7 @@ class Epoch(models.Model):
         """
 
         if len(reduced_L) > 0:
-            if iop4conf.nprocs > 1:
+            if iop4conf.nthreads > 1:
                 epoch_bulkreduce_multiprocesing(reduced_L, epoch=epoch)
             else:
                 epoch_bulkreduce_onebyone(reduced_L, epoch=epoch)
@@ -624,7 +624,7 @@ class Epoch(models.Model):
 
         f = lambda x: Instrument.by_name(x[1]['instrument']).compute_relative_polarimetry(x[0])
 
-        if iop4conf.nprocs > 1:
+        if iop4conf.nthreads > 1:
             # parallel
             from iop4lib.utils.parallel import parallel_relative_polarimetry
             parallel_relative_polarimetry(groupkeys_L, clusters_L)

--- a/iop4lib/db/epoch.py
+++ b/iop4lib/db/epoch.py
@@ -418,7 +418,7 @@ class Epoch(models.Model):
         the BUILT_REDUCED flag) will be reduced, else all rawfits of this epoch of type LIGHT be 
         reduced.
 
-        If iop4conf.max_concurrent_threads > 1, the reduction will be done in parallel processes.
+        If iop4conf.nprocs > 1, the reduction will be done in parallel processes.
         """
 
         Epoch.reduce_rawfits(self.rawfits.filter(imgtype=IMGTYPES.LIGHT), force_rebuild=force_rebuild, epoch=self)
@@ -434,7 +434,7 @@ class Epoch(models.Model):
         If force_rebuild is False, only rawfits that have not been reduced yet (that do not have 
         the BUILT_REDUCED flag) will be reduced, else all rawfits in the list will be reduced.
 
-        If iop4conf.max_concurrent_threads > 1, the reduction will be done in parallel processes.
+        If iop4conf.nprocs > 1, the reduction will be done in parallel processes.
 
         Parameters
         ----------
@@ -462,7 +462,7 @@ class Epoch(models.Model):
     def reduce_reducedfits(reduced_L, epoch=None):
         """ Bulk reduces a list of ReducedFit in a multiprocessing pool. 
         
-        If iop4conf.max_concurrent_threads > 1, the reduction will be done in parallel processes.
+        If iop4conf.nprocs > 1, the reduction will be done in parallel processes.
 
         Parameters
         ----------
@@ -478,7 +478,7 @@ class Epoch(models.Model):
         """
 
         if len(reduced_L) > 0:
-            if iop4conf.max_concurrent_threads > 1:
+            if iop4conf.nprocs > 1:
                 epoch_bulkreduce_multiprocesing(reduced_L, epoch=epoch)
             else:
                 epoch_bulkreduce_onebyone(reduced_L, epoch=epoch)
@@ -624,7 +624,7 @@ class Epoch(models.Model):
 
         f = lambda x: Instrument.by_name(x[1]['instrument']).compute_relative_polarimetry(x[0])
 
-        if iop4conf.max_concurrent_threads > 1:
+        if iop4conf.nprocs > 1:
             # parallel
             from iop4lib.utils.parallel import parallel_relative_polarimetry
             parallel_relative_polarimetry(groupkeys_L, clusters_L)

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -281,7 +281,7 @@ def main():
     # check if log_file is a path or just the file name, if it is a path, use it, if not, use datadir/logs/log_file
 
     if os.path.dirname(iop4conf.log_file) == '':
-        iop4conf.log_file = (Path(iop4conf.datadir) / "logs" / iop4conf.log_file)
+        iop4conf.log_file = str(Path(iop4conf.datadir) / "logs" / iop4conf.log_file)
 
     if iop4conf.log_file == "$date":
         iop4conf.log_file = str(Path(iop4conf.datadir) / "logs" / datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S') + ".log")

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -278,14 +278,6 @@ def main():
 
     ## configure logging
 
-    # check if log_file is a path or just the file name, if it is a path, use it, if not, use datadir/logs/log_file
-
-    if os.path.dirname(iop4conf.log_file) == '':
-        iop4conf.log_file = str(Path(iop4conf.datadir).expanduser() / "logs" / iop4conf.log_file)
-
-    if iop4conf.log_file == "$date":
-        iop4conf.log_file = str(Path(iop4conf.datadir).expanduser() / "logs" / datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S') + ".log")
-
     ROOT_LOGGER = logging.getLogger()
     
     ROOT_LOGGER.setLevel(iop4conf.log_level)

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -239,28 +239,28 @@ def main():
     
     # epoch processing options
     parser.add_argument('--epoch-list', dest='epochname_list', nargs='+', help='<Optional> List of epochs (e.g: T090/230102 T090/230204)', required=False)
-    parser.add_argument('--discover-missing', dest='discover_missing', action='store_true', help='<Optional> Discover new epochs to process them', required=False)
-    parser.add_argument('--list-local', dest='list_local', action='store_true', help='<Optional> Discover local epochs to process them', required=False)
-    parser.add_argument('--list-only', dest='list_only', action='store_true', help='<Optional> If given, the built list of epochs will be printed but not processed', required=False)
+    parser.add_argument('--discover-missing', action='store_true', help='<Optional> Discover new epochs to process them', required=False)
+    parser.add_argument('--list-local', action='store_true', help='<Optional> Discover local epochs to process them', required=False)
+    parser.add_argument('--list-only', action='store_true', help='<Optional> If given, the built list of epochs will be printed but not processed', required=False)
     parser.add_argument('--no-check-db', dest='keep_epochs_in_db', action='store_true', help='<Optional> Process discovered epochs even if they existed in archive', required=False)
 
     ## file processing  options
     parser.add_argument('--file-list', dest='fileloc_list', nargs='+', help='<Optional> List of files (e.g: tel/yyyy-mm-dd/name))', required=False)
-    parser.add_argument('--discover-missing-files', dest='discover_missing_files', action='store_true', help='<Optional> Discover files in remote archives that are not present in archive', required=False)
-    parser.add_argument('--list-local-files',  dest='list_local_files', action='store_true', help='<Optional> Discover local files to process them', required=False)
-    parser.add_argument('--list-files-only', dest='list_files_only', action='store_true', help='<Optional> If given, the built list of filelocs will be printed but not processed', required=False)
+    parser.add_argument('--discover-missing-files', action='store_true', help='<Optional> Discover files in remote archives that are not present in archive', required=False)
+    parser.add_argument('--list-local-files', action='store_true', help='<Optional> Discover local files to process them', required=False)
+    parser.add_argument('--list-files-only', action='store_true', help='<Optional> If given, the built list of filelocs will be printed but not processed', required=False)
     parser.add_argument('--no-check-db-files',  dest='keep_files_in_db', action='store_true', help='<Optional> Process discovered files even if they existed in archive', required=False)
     
 
     # other options
-    parser.add_argument('--skip-remote-file-list', dest='skip_remote_file_list', action='store_true', help='<Optional> Skip remote file list check', required=False)
-    parser.add_argument("--force-rebuild", dest="force_rebuild", action="store_true", help="<Optional> Force re-building of files (pass force_rebuild=True)", required=False)
-    parser.add_argument('--retry-failed', dest='retry_failed', action='store_true', help='<Optional> Retry failed reduced fits', required=False)
+    parser.add_argument('--skip-remote-file-list', action='store_true', help='<Optional> Skip remote file list check', required=False)
+    parser.add_argument("--force-rebuild", action="store_true", help="<Optional> Force re-building of files (pass force_rebuild=True)", required=False)
+    parser.add_argument('--retry-failed', action='store_true', help='<Optional> Retry failed reduced fits', required=False)
     parser.add_argument('--reclassify-rawfits', dest="reclassify_rawfits", action="store_true", help="<Optional> Re-classify rawfits", required=False)
 
     # range
-    parser.add_argument('--date-start', '-s', dest='date_start', type=str, default=None, help='<Optional> Start date (YYYY-MM-DD)', required=False)
-    parser.add_argument('--date-end', '-e', dest='date_end', type=str, default=None, help='<Optional> End date (YYYY-MM-DD)', required=False)
+    parser.add_argument('--date-start', '-s', type=str, default=None, help='<Optional> Start date (YYYY-MM-DD)', required=False)
+    parser.add_argument('--date-end', '-e', type=str, default=None, help='<Optional> End date (YYYY-MM-DD)', required=False)
 
     args = parser.parse_args()
 
@@ -281,10 +281,10 @@ def main():
     # check if log_file is a path or just the file name, if it is a path, use it, if not, use datadir/logs/log_file
 
     if os.path.dirname(iop4conf.log_file) == '':
-        iop4conf.log_file = str(Path(iop4conf.datadir) / "logs" / iop4conf.log_file)
+        iop4conf.log_file = str(Path(iop4conf.datadir).expanduser() / "logs" / iop4conf.log_file)
 
     if iop4conf.log_file == "$date":
-        iop4conf.log_file = str(Path(iop4conf.datadir) / "logs" / datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S') + ".log")
+        iop4conf.log_file = str(Path(iop4conf.datadir).expanduser() / "logs" / datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S') + ".log")
 
     ROOT_LOGGER = logging.getLogger()
     

--- a/iop4lib/utils/astrometry.py
+++ b/iop4lib/utils/astrometry.py
@@ -403,7 +403,7 @@ def _save_astrocalib_proc_vars(locals_dict):
 #"""
 # The wrapper uses the `multiprocess` package instead of `multiprocessing` because the latter does 
 # not allow for daemon processes to have children, and solve_astrometry is invoked from a Pool of 
-# processes when iop4conf.nprocs > 1, and Pool's processes are daemons. Another 
+# processes when iop4conf.nthreads > 1, and Pool's processes are daemons. Another 
 # alternative would have been to start the concurrent threads using Process instead of Pool 
 # with daemon=False. 
 #

--- a/iop4lib/utils/astrometry.py
+++ b/iop4lib/utils/astrometry.py
@@ -403,7 +403,7 @@ def _save_astrocalib_proc_vars(locals_dict):
 #"""
 # The wrapper uses the `multiprocess` package instead of `multiprocessing` because the latter does 
 # not allow for daemon processes to have children, and solve_astrometry is invoked from a Pool of 
-# processes when iop4conf.max_concurrent_threads > 1, and Pool's processes are daemons. Another 
+# processes when iop4conf.nprocs > 1, and Pool's processes are daemons. Another 
 # alternative would have been to start the concurrent threads using Process instead of Pool 
 # with daemon=False. 
 #

--- a/iop4lib/utils/parallel.py
+++ b/iop4lib/utils/parallel.py
@@ -29,7 +29,7 @@ def epoch_bulkreduce_multiprocesing(reduced_L, epoch=None):
     """ Reduces a list of ReducedFit instances in a multiprocessing pool.
 
     Invokes the reduction of a list of ReducedFit instances in a multiprocessing pool, with a maximum number of
-    concurrent processes defined by iop4conf.max_concurrent_threads. It can be invoked with a list of ReducedFit 
+    concurrent processes defined by iop4conf.nprocs. It can be invoked with a list of ReducedFit 
     from different epochs.
 
     Parameters
@@ -43,7 +43,7 @@ def epoch_bulkreduce_multiprocesing(reduced_L, epoch=None):
         If provided, it is used only to print the epoch in the log messages of the main thread.
     """
 
-    logger.info(f"{epoch}: starting {iop4conf.max_concurrent_threads} threads to build {len(reduced_L)} reduced files. Current memory usage: {get_mem_current()/1024**3:.2f} GB.")
+    logger.info(f"{epoch}: starting {iop4conf.nprocs} threads to build {len(reduced_L)} reduced files. Current memory usage: {get_mem_current()/1024**3:.2f} GB.")
 
     mp_ctx = multiprocessing.get_context('spawn')
 
@@ -53,7 +53,7 @@ def epoch_bulkreduce_multiprocesing(reduced_L, epoch=None):
     
     counter = mp_ctx.Value('i', 0)
 
-    with mp_ctx.Pool(processes=iop4conf.max_concurrent_threads, 
+    with mp_ctx.Pool(processes=iop4conf.nprocs, 
                               initializer=_epoch_bulkreduce_multiprocessing_init,
                               initargs=(counter, queue, len(reduced_L), iop4conf), 
                               maxtasksperchild=20) as pool:
@@ -210,6 +210,6 @@ def _parallel_relative_polarimetry_helper(keys, group):
         logger.info(f"Finished computing relative polarimetry for {group=}.")
 
 def parallel_relative_polarimetry(keys, groups):
-    with multiprocessing.Pool(iop4conf.max_concurrent_threads) as pool:
+    with multiprocessing.Pool(iop4conf.nprocs) as pool:
         pool.starmap(_parallel_relative_polarimetry_helper, zip(keys, groups))
 

--- a/iop4lib/utils/parallel.py
+++ b/iop4lib/utils/parallel.py
@@ -29,7 +29,7 @@ def epoch_bulkreduce_multiprocesing(reduced_L, epoch=None):
     """ Reduces a list of ReducedFit instances in a multiprocessing pool.
 
     Invokes the reduction of a list of ReducedFit instances in a multiprocessing pool, with a maximum number of
-    concurrent processes defined by iop4conf.nprocs. It can be invoked with a list of ReducedFit 
+    concurrent processes defined by iop4conf.nthreads. It can be invoked with a list of ReducedFit 
     from different epochs.
 
     Parameters
@@ -43,7 +43,7 @@ def epoch_bulkreduce_multiprocesing(reduced_L, epoch=None):
         If provided, it is used only to print the epoch in the log messages of the main thread.
     """
 
-    logger.info(f"{epoch}: starting {iop4conf.nprocs} threads to build {len(reduced_L)} reduced files. Current memory usage: {get_mem_current()/1024**3:.2f} GB.")
+    logger.info(f"{epoch}: starting {iop4conf.nthreads} threads to build {len(reduced_L)} reduced files. Current memory usage: {get_mem_current()/1024**3:.2f} GB.")
 
     mp_ctx = multiprocessing.get_context('spawn')
 
@@ -53,7 +53,7 @@ def epoch_bulkreduce_multiprocesing(reduced_L, epoch=None):
     
     counter = mp_ctx.Value('i', 0)
 
-    with mp_ctx.Pool(processes=iop4conf.nprocs, 
+    with mp_ctx.Pool(processes=iop4conf.nthreads, 
                               initializer=_epoch_bulkreduce_multiprocessing_init,
                               initargs=(counter, queue, len(reduced_L), iop4conf), 
                               maxtasksperchild=20) as pool:
@@ -210,6 +210,6 @@ def _parallel_relative_polarimetry_helper(keys, group):
         logger.info(f"Finished computing relative polarimetry for {group=}.")
 
 def parallel_relative_polarimetry(keys, groups):
-    with multiprocessing.Pool(iop4conf.nprocs) as pool:
+    with multiprocessing.Pool(iop4conf.nthreads) as pool:
         pool.starmap(_parallel_relative_polarimetry_helper, zip(keys, groups))
 

--- a/tests/test_caha_cafos.py
+++ b/tests/test_caha_cafos.py
@@ -42,7 +42,7 @@ def test_build_single_proc(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.nprocs = 1
+    iop4conf.nthreads = 1
 
     rawfits = RawFit.objects.filter(epoch__in=epoch_L, imgtype=IMGTYPES.LIGHT).all()
     
@@ -76,7 +76,7 @@ def test_build_multi_proc_photopol(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.nprocs = 4
+    iop4conf.nthreads = 4
 
     rawfits = RawFit.objects.filter(epoch__in=epoch_L, imgtype=IMGTYPES.LIGHT).all()
     

--- a/tests/test_caha_cafos.py
+++ b/tests/test_caha_cafos.py
@@ -42,7 +42,7 @@ def test_build_single_proc(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.max_concurrent_threads = 1
+    iop4conf.nprocs = 1
 
     rawfits = RawFit.objects.filter(epoch__in=epoch_L, imgtype=IMGTYPES.LIGHT).all()
     
@@ -76,7 +76,7 @@ def test_build_multi_proc_photopol(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.max_concurrent_threads = 4
+    iop4conf.nprocs = 4
 
     rawfits = RawFit.objects.filter(epoch__in=epoch_L, imgtype=IMGTYPES.LIGHT).all()
     

--- a/tests/test_osnt090_andor.py
+++ b/tests/test_osnt090_andor.py
@@ -76,7 +76,7 @@ def test_build_single_proc(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.nprocs = 1
+    iop4conf.nthreads = 1
 
     epoch = Epoch.by_epochname("OSN-T090/2022-09-18")
     
@@ -108,7 +108,7 @@ def test_build_multi_proc_photopol(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.nprocs = 6
+    iop4conf.nthreads = 6
 
     rawfits = RawFit.objects.filter(epoch__in=epoch_L, imgtype=IMGTYPES.LIGHT).all()
     

--- a/tests/test_osnt090_andor.py
+++ b/tests/test_osnt090_andor.py
@@ -76,7 +76,7 @@ def test_build_single_proc(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.max_concurrent_threads = 1
+    iop4conf.nprocs = 1
 
     epoch = Epoch.by_epochname("OSN-T090/2022-09-18")
     
@@ -108,7 +108,7 @@ def test_build_multi_proc_photopol(load_test_catalog):
         epoch.build_master_biases()
         epoch.build_master_flats()
 
-    iop4conf.max_concurrent_threads = 6
+    iop4conf.nprocs = 6
 
     rawfits = RawFit.objects.filter(epoch__in=epoch_L, imgtype=IMGTYPES.LIGHT).all()
     


### PR DESCRIPTION
This PR:
  - adds support for overriding any config option from the command line as `iop4 -o option1=value1 -o option2=value [...]`.
  - improves the filtering and highlighting by a search string in the web gui log viewer. 
      
     Now it correctly highlights any string without breaking the html log, and the page does not become unresponsive when filtering and highlighting big logs. It also starts showing the log as it receives it, instead of loading it whole first.
  - adds support for showing multiple logs in the web. Now logs are stored in the `[datadir]/logs/` directory, and the portal allows selecting any log file to display. This will allow datachekers to inspect the logs from different and previous runs of iop4.