### PR TITLE
Add iop4 cmd option to check config file

### DIFF
--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -202,3 +202,30 @@ class Config(dict):
             return
         
         logging.setLogRecordFactory(record_factory_w_proc_memory)
+
+
+    def check_config(self):
+        r""" Checks that the configuration file is correct by comparing it with the default one.
+        
+        Returns
+        -------
+        bool
+            True if the configuration file is correct, False otherwise.
+
+        """
+
+        with open(self.config_path, 'r') as f:
+            config_dict = yaml.safe_load(f)
+
+        with open(pathlib.Path(self.basedir) / "config" / "config.example.yaml", 'r') as f:
+            config_dict_example = yaml.safe_load(f)
+
+        wrong = False
+
+        for k, v in config_dict_example.items():
+            if k not in config_dict:
+                # print because logging might not be configured yet
+                print(f"ERROR: {k} missing in config file.")
+                wrong = True
+
+        return not wrong

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -7,6 +7,10 @@ import matplotlib, matplotlib.pyplot
 
 matplotlib.pyplot.set_loglevel('warning')
 
+# logging
+import logging
+logger = logging.getLogger(__name__)
+
 # Set journal_mode=WAL and synchronous=NORMAL for sqlite3 databases on 
 # connection, to improve support for concurrent write access to the 
 # database during parallel reduction
@@ -204,7 +208,7 @@ class Config(dict):
         logging.setLogRecordFactory(record_factory_w_proc_memory)
 
 
-    def check_config(self):
+    def is_valid(self):
         r""" Checks that the configuration file is correct by comparing it with the default one.
         
         Returns
@@ -224,8 +228,7 @@ class Config(dict):
 
         for k, v in config_dict_example.items():
             if k not in config_dict:
-                # print because logging might not be configured yet
-                print(f"ERROR: {k} missing in config file.")
+                logger.error(f"ERROR: {k} missing in config file.")
                 wrong = True
 
         return not wrong

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -235,7 +235,7 @@ def main():
                     allow_abbrev=False)
     
     parser.add_argument('-i', "--interactive", dest="interactive", action="store_true", help="<Optional> Jump to an IPython shell after finishing execution")
-    parser.add_argument('--check-config', action="store_true", help="<Optional> Check the configuration file")
+    parser.add_argument('--no-check-config', action="store_true", help="<Optional> Check the configuration file")
     parser.add_argument('-o', action='append', dest='config_overrides', help="Override a config option (e.g., -o option=value)")
     
     # epoch processing options
@@ -271,7 +271,7 @@ def main():
 
     # Configuration:
 
-    if args.check_config:
+    if not args.no_check_config:
         if not iop4conf.is_valid():
             print("check_config: there are some missing keys in the config file. All keys in the example config file must be present. Add them to your config file (you can set them to null) and try again.")
             sys.exit(-1)

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -234,34 +234,34 @@ def main():
                     formatter_class=argparse.RawDescriptionHelpFormatter,
                     allow_abbrev=False)
     
-    parser.add_argument('-i', "--interactive", dest="interactive", action="store_true", help="<Optional> Jump to an IPython shell after finishing execution", required=False)
-    parser.add_argument('--check-config', dest="check_config", action="store_true", help="<Optional> Check the configuration file", required=False)
+    parser.add_argument('-i', "--interactive", dest="interactive", action="store_true", help="<Optional> Jump to an IPython shell after finishing execution")
+    parser.add_argument('--check-config', action="store_true", help="<Optional> Check the configuration file")
     parser.add_argument('-o', action='append', dest='config_overrides', help="Override a config option (e.g., -o option=value)")
     
     # epoch processing options
-    parser.add_argument('--epoch-list', dest='epochname_list', nargs='+', help='<Optional> List of epochs (e.g: T090/230102 T090/230204)', required=False)
-    parser.add_argument('--discover-missing', action='store_true', help='<Optional> Discover new epochs to process them', required=False)
-    parser.add_argument('--list-local', action='store_true', help='<Optional> Discover local epochs to process them', required=False)
-    parser.add_argument('--list-only', action='store_true', help='<Optional> If given, the built list of epochs will be printed but not processed', required=False)
-    parser.add_argument('--no-check-db', dest='keep_epochs_in_db', action='store_true', help='<Optional> Process discovered epochs even if they existed in archive', required=False)
+    parser.add_argument('--epoch-list', dest='epochname_list', nargs='+', help='<Optional> List of epochs (e.g: T090/230102 T090/230204)')
+    parser.add_argument('--discover-missing', action='store_true', help='<Optional> Discover new epochs to process them')
+    parser.add_argument('--list-local', action='store_true', help='<Optional> Discover local epochs to process them')
+    parser.add_argument('--list-only', action='store_true', help='<Optional> If given, the built list of epochs will be printed but not processed')
+    parser.add_argument('--no-check-db', dest='keep_epochs_in_db', action='store_true', help='<Optional> Process discovered epochs even if they existed in archive')
 
     ## file processing  options
-    parser.add_argument('--file-list', dest='fileloc_list', nargs='+', help='<Optional> List of files (e.g: tel/yyyy-mm-dd/name))', required=False)
-    parser.add_argument('--discover-missing-files', action='store_true', help='<Optional> Discover files in remote archives that are not present in archive', required=False)
-    parser.add_argument('--list-local-files', action='store_true', help='<Optional> Discover local files to process them', required=False)
-    parser.add_argument('--list-files-only', action='store_true', help='<Optional> If given, the built list of filelocs will be printed but not processed', required=False)
-    parser.add_argument('--no-check-db-files',  dest='keep_files_in_db', action='store_true', help='<Optional> Process discovered files even if they existed in archive', required=False)
+    parser.add_argument('--file-list', dest='fileloc_list', nargs='+', help='<Optional> List of files (e.g: tel/yyyy-mm-dd/name))')
+    parser.add_argument('--discover-missing-files', action='store_true', help='<Optional> Discover files in remote archives that are not present in archive')
+    parser.add_argument('--list-local-files', action='store_true', help='<Optional> Discover local files to process them')
+    parser.add_argument('--list-files-only', action='store_true', help='<Optional> If given, the built list of filelocs will be printed but not processed')
+    parser.add_argument('--no-check-db-files',  dest='keep_files_in_db', action='store_true', help='<Optional> Process discovered files even if they existed in archive')
     
 
     # other options
-    parser.add_argument('--skip-remote-file-list', action='store_true', help='<Optional> Skip remote file list check', required=False)
-    parser.add_argument("--force-rebuild", action="store_true", help="<Optional> Force re-building of files (pass force_rebuild=True)", required=False)
-    parser.add_argument('--retry-failed', action='store_true', help='<Optional> Retry failed reduced fits', required=False)
-    parser.add_argument('--reclassify-rawfits', dest="reclassify_rawfits", action="store_true", help="<Optional> Re-classify rawfits", required=False)
+    parser.add_argument('--skip-remote-file-list', action='store_true', help='<Optional> Skip remote file list check')
+    parser.add_argument("--force-rebuild", action="store_true", help="<Optional> Force re-building of files (pass force_rebuild=True)")
+    parser.add_argument('--retry-failed', action='store_true', help='<Optional> Retry failed reduced fits')
+    parser.add_argument('--reclassify-rawfits', dest="reclassify_rawfits", action="store_true", help="<Optional> Re-classify rawfits")
 
     # range
-    parser.add_argument('--date-start', '-s', type=str, default=None, help='<Optional> Start date (YYYY-MM-DD)', required=False)
-    parser.add_argument('--date-end', '-e', type=str, default=None, help='<Optional> End date (YYYY-MM-DD)', required=False)
+    parser.add_argument('--date-start', '-s', type=str, default=None, help='<Optional> Start date (YYYY-MM-DD)')
+    parser.add_argument('--date-end', '-e', type=str, default=None, help='<Optional> End date (YYYY-MM-DD)')
 
     args = parser.parse_args()
 
@@ -272,7 +272,7 @@ def main():
     # Configuration:
 
     if args.check_config:
-        if not iop4conf.check_config():
+        if not iop4conf.is_valid():
             print("check_config: there are some missing keys in the config file. All keys in the example config file must be present. Add them to your config file (you can set them to null) and try again.")
             sys.exit(-1)
         else:

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -235,7 +235,7 @@ def main():
                     allow_abbrev=False)
     
     parser.add_argument('-i', "--interactive", dest="interactive", action="store_true", help="<Optional> Jump to an IPython shell after finishing execution")
-    parser.add_argument('--no-check-config', action="store_true", help="<Optional> Check the configuration file")
+    parser.add_argument('--check-config', action="store_true", help="<Optional> Check the configuration file")
     parser.add_argument('-o', action='append', dest='config_overrides', help="Override a config option (e.g., -o option=value)")
     
     # epoch processing options
@@ -271,12 +271,11 @@ def main():
 
     # Configuration:
 
-    if not args.no_check_config:
-        if not iop4conf.is_valid():
-            print("check_config: there are some missing keys in the config file. All keys in the example config file must be present. Add them to your config file (you can set them to null) and try again.")
-            sys.exit(-1)
-        else:
-            print("check_config: config file is OK.")
+    if not iop4conf.is_valid():
+        print("check_config: there are some missing keys in the config file. All keys in the example config file must be present. Add them to your config file (you can set them to null) and try again. Aborting.")
+        sys.exit(-1)
+    elif args.check_config:
+        print("check_config: config file is OK.")
 
     if args.config_overrides:
         # get the config options as a dict

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -235,6 +235,7 @@ def main():
                     allow_abbrev=False)
     
     parser.add_argument('-i', "--interactive", dest="interactive", action="store_true", help="<Optional> Jump to an IPython shell after finishing execution", required=False)
+    parser.add_argument('--check-config', dest="check_config", action="store_true", help="<Optional> Check the configuration file", required=False)
     parser.add_argument('-o', action='append', dest='config_overrides', help="Override a config option (e.g., -o option=value)")
     
     # epoch processing options
@@ -269,6 +270,13 @@ def main():
         sys.exit(0)
 
     # Configuration:
+
+    if args.check_config:
+        if not iop4conf.check_config():
+            print("check_config: there are some missing keys in the config file. All keys in the example config file must be present. Add them to your config file (you can set them to null) and try again.")
+            sys.exit(-1)
+        else:
+            print("check_config: config file is OK.")
 
     if args.config_overrides:
         # get the config options as a dict


### PR DESCRIPTION
As the title says, this PR adds the `iop4 --check-config` option to check that there are no missing keys in the config file by comparing it to the example one. This is useful to make sure that the used config file is up to date with the iop4 version.