### PR TITLE
Adapt IOP4 to work on historic (2007-2021/22) data

### DIFF
--- a/docs/data_reduction_details.rst
+++ b/docs/data_reduction_details.rst
@@ -54,11 +54,11 @@ OSN T090 Information
 
 RoperT90 instrument (photometry, polarimetry with filters). Retired 23rd October 2021.
 
-* Old camera: https://www.osn.iaa.csic.es/page/camara-versarray-t90-retirada
+* More information about the RoperT90 camera: https://www.osn.iaa.csic.es/page/camara-versarray-t90-retirada
 
 AndorT90 instrument (photometry, polarimetry with filters):
 
-* Information about the camera: https://www.osn.iaa.csic.es/page/camaras-ccdt150-y-ccdt90
+* Information about the AndorT90 camera: https://www.osn.iaa.csic.es/page/camaras-ccdt150-y-ccdt90
 
 DIPOL polarimeter: :cite:t:`dipol:2020`.
 

--- a/docs/data_reduction_details.rst
+++ b/docs/data_reduction_details.rst
@@ -50,11 +50,15 @@ CAHA T220 Information
 OSN T090 Information
 --------------------
 
+* Information about the telescope: https://www.osn.iaa.csic.es/page/telescopio-90-cm
+
+RoperT90 instrument (photometry, polarimetry with filters). Retired 23rd October 2021.
+
+* Old camera: https://www.osn.iaa.csic.es/page/camara-versarray-t90-retirada
+
 AndorT90 instrument (photometry, polarimetry with filters):
 
-* Information about the telescope: https://www.osn.iaa.csic.es/page/telescopio-90-cm
 * Information about the camera: https://www.osn.iaa.csic.es/page/camaras-ccdt150-y-ccdt90
-* Old camera: https://www.osn.iaa.csic.es/page/camara-versarray-t90-retirada
 
 DIPOL polarimeter: :cite:t:`dipol:2020`.
 

--- a/iop4lib/enums.py
+++ b/iop4lib/enums.py
@@ -42,6 +42,7 @@ class INSTRUMENTS(models.TextChoices):
 
     NONE = None, "None"
     CAFOS = 'CAFOS2.2', "CAFOS2.2"
+    RoperT90 = 'RoperT90', "RoperT90"
     AndorT90 = 'AndorT90', "AndorT90"
     AndorT150 = 'AndorT150', "AndorT150"
     DIPOL = 'DIPOL', "DIPOL"

--- a/iop4lib/instruments/__init__.py
+++ b/iop4lib/instruments/__init__.py
@@ -1,4 +1,4 @@
 from .instrument import Instrument
-from .andor_cameras import AndorT90, AndorT150
+from .osn_cameras import RoperT90, AndorT90, AndorT150
 from .cafos import CAFOS
 from .dipol import DIPOL

--- a/iop4lib/instruments/cafos.py
+++ b/iop4lib/instruments/cafos.py
@@ -83,14 +83,15 @@ class CAFOS(Instrument):
     @classmethod
     def classify_band_rawfit(cls, rawfit):
         """
-        INSFLNAM is BesselR ??
+        Older data (.e.g 2007): INSFLNAM = John R
+        New data (e.g. 2022): INSFLNAM = BessellR
         """
 
         from iop4lib.db.rawfit import RawFit
         import astropy.io.fits as fits
 
         if 'INSFLNAM' in rawfit.header:
-            if rawfit.header['INSFLNAM'] == 'BessellR':
+            if rawfit.header['INSFLNAM'] == 'BessellR' or rawfit.header['INSFLNAM'] == 'John R':
                 rawfit.band = BANDS.R
             else:
                 logger.error(f"{rawfit}: unknown filter {rawfit.header['INSFLNAM']}.")

--- a/iop4lib/instruments/cafos.py
+++ b/iop4lib/instruments/cafos.py
@@ -83,7 +83,7 @@ class CAFOS(Instrument):
     @classmethod
     def classify_band_rawfit(cls, rawfit):
         """
-        Older data (.e.g 2007): INSFLNAM = John R
+        Older data (e.g. 2007): INSFLNAM = John R or INSFLNAM = Cous R
         New data (e.g. 2022): INSFLNAM = BessellR
         """
 
@@ -91,7 +91,9 @@ class CAFOS(Instrument):
         import astropy.io.fits as fits
 
         if 'INSFLNAM' in rawfit.header:
-            if rawfit.header['INSFLNAM'] == 'BessellR' or rawfit.header['INSFLNAM'] == 'John R':
+            if (rawfit.header['INSFLNAM'] == 'BessellR' or 
+                rawfit.header['INSFLNAM'] == 'John R' or 
+                rawfit.header['INSFLNAM'] == 'Cous R'):
                 rawfit.band = BANDS.R
             else:
                 logger.error(f"{rawfit}: unknown filter {rawfit.header['INSFLNAM']}.")

--- a/iop4lib/instruments/cafos.py
+++ b/iop4lib/instruments/cafos.py
@@ -27,8 +27,9 @@ if typing.TYPE_CHECKING:
 class CAFOS(Instrument):
         
     name = "CAFOS2.2"
-    instrument_kw = "CAFOS 2.2"
     telescope = CAHAT220.name
+
+    instrument_kw_L = ["CAFOS 2.2"]
 
     arcsec_per_pix = 0.530
     gain_e_adu = 1.45

--- a/iop4lib/instruments/cafos.py
+++ b/iop4lib/instruments/cafos.py
@@ -94,7 +94,7 @@ class CAFOS(Instrument):
         if 'INSFLNAM' in rawfit.header:
             if (rawfit.header['INSFLNAM'] == 'BessellR' or 
                 rawfit.header['INSFLNAM'] == 'John R' or 
-                rawfit.header['INSFLNAM'] == 'Cous R'):
+                rawfit.header['INSFLNAM'] == 'Cous R' or rawfit.header['INSFLNAM'] == 'CousinsR'):
                 rawfit.band = BANDS.R
             else:
                 logger.error(f"{rawfit}: unknown filter {rawfit.header['INSFLNAM']}.")

--- a/iop4lib/instruments/cafos.py
+++ b/iop4lib/instruments/cafos.py
@@ -76,6 +76,8 @@ class CAFOS(Instrument):
                 rawfit.imgtype = IMGTYPES.BIAS
             elif hdul[0].header['IMAGETYP'] == 'science':
                 rawfit.imgtype = IMGTYPES.LIGHT
+            elif hdul[0].header['IMAGETYP'] == 'dark':
+                rawfit.imgtype = IMGTYPES.DARK
             else:
                 logger.error(f"Unknown image type for {rawfit.fileloc}.")
                 rawfit.imgtype = IMGTYPES.ERROR
@@ -84,8 +86,10 @@ class CAFOS(Instrument):
     @classmethod
     def classify_band_rawfit(cls, rawfit):
         """
-        Older data (e.g. 2007): INSFLNAM = John R or INSFLNAM = Cous R
-        New data (e.g. 2022): INSFLNAM = BessellR
+        Older data (e.g. 2007): INSFLNAM = 'John R' or INSFLNAM = 'Cous R'
+        New data (e.g. 2022): INSFLNAM = 'BessellR'
+
+        There are also images in the archive with INSFLNAM = 'John V' and INSFLNAM = 'John I', and INSFLNAM = 'free'
         """
 
         from iop4lib.db.rawfit import RawFit

--- a/iop4lib/instruments/dipol.py
+++ b/iop4lib/instruments/dipol.py
@@ -37,7 +37,7 @@ from iop4lib.utils import imshow_w_sources, get_candidate_rank_by_matchs, get_an
 from iop4lib.utils.sourcedetection import get_sources_daofind, get_segmentation, get_cat_sources_from_segment_map, get_bkg
 from iop4lib.utils.plotting import plot_preview_astrometry
 from iop4lib.utils.astrometry import BuildWCSResult
-
+from iop4lib.telescopes import OSNT090
 
 # logging
 import logging
@@ -51,8 +51,10 @@ if typing.TYPE_CHECKING:
 class DIPOL(Instrument):
 
     name = "DIPOL"
-    instrument_kw = "ASI Camera (1)"
-    
+    telescope = OSNT090.name
+
+    instrument_kw_L = ["ASI Camera (1)"]
+
     arcsec_per_pix = 0.134
     field_width_arcmin = 9.22
     field_height_arcmin = 6.28 

--- a/iop4lib/instruments/instrument.py
+++ b/iop4lib/instruments/instrument.py
@@ -128,8 +128,8 @@ class Instrument(metaclass=ABCMeta):
     @classmethod
     def check_instrument_kw(cls, rawfit):
         """ Check that the instrument keyword is correct. """
-        if rawfit.header["INSTRUME"] != cls.instrument_kw:
-            raise ValueError(f"Raw fit file {rawfit.fileloc} has INSTRUME != {cls.instrument_kw}.")
+        if rawfit.header["INSTRUME"] not in cls.instrument_kw_L:
+            raise ValueError(f"Raw fit file {rawfit.fileloc} has INSTRUME not in {cls.instrument_kw_L}.")
 
     @classmethod
     def classify_imgsize(cls, rawfit):

--- a/iop4lib/instruments/instrument.py
+++ b/iop4lib/instruments/instrument.py
@@ -93,11 +93,11 @@ class Instrument(metaclass=ABCMeta):
     @classmethod
     def get_known(cls):
         """ Return a list of all known instruments subclasses."""
-        from .andor_cameras import AndorT90, AndorT150
+        from .osn_cameras import RoperT90, AndorT90, AndorT150
         from .cafos import CAFOS
         from .dipol import DIPOL
 
-        return [AndorT90, AndorT150, CAFOS, DIPOL]
+        return [RoperT90, AndorT90, AndorT150, CAFOS, DIPOL]
 
     @classmethod
     def by_name(cls, name: str) -> 'Instrument':

--- a/iop4lib/instruments/osn_cameras.py
+++ b/iop4lib/instruments/osn_cameras.py
@@ -420,9 +420,9 @@ class OSNCCDCamera(Instrument, metaclass=ABCMeta):
 class AndorT90(OSNCCDCamera):
     
     name = "AndorT90"
-    instrument_kw = "AndorT90"
     telescope = OSNT090.name
 
+    instrument_kw_L = ["AndorT90", "RoperT90"] # RoperT90 only in some old images before the PC was updated after camera replacement
 
     field_width_arcmin = 13.2 
     field_height_arcmin = 13.2
@@ -449,8 +449,9 @@ class AndorT90(OSNCCDCamera):
 class AndorT150(OSNCCDCamera):
         
     name = "AndorT150"
-    instrument_kw = "Andor"
     telescope = OSNT150.name
+
+    instrument_kw_L = ["Andor", "AndorT150"]
 
     arcsec_per_pix = 0.232
     gain_e_adu = 4.5
@@ -460,8 +461,9 @@ class AndorT150(OSNCCDCamera):
 
 class RoperT90(OSNCCDCamera):
     name = "RoperT90"
-    instrument_kw = "RoperT90"
     telescope = OSNT090.name
+
+    instrument_kw_L = ["RoperT90"]
 
     arcsec_per_pix = 0.387
     gain_e_adu = 7.14

--- a/iop4lib/instruments/osn_cameras.py
+++ b/iop4lib/instruments/osn_cameras.py
@@ -25,8 +25,8 @@ import typing
 if typing.TYPE_CHECKING:
     from iop4lib.db.reducedfit import ReducedFit, RawFit
 
-class Andor(Instrument, metaclass=ABCMeta):
-    r""" Abstract class for OSN Andor cameras."""
+class OSNCCDCamera(Instrument, metaclass=ABCMeta):
+    r""" Abstract class for OSN CCD cameras. """
 
     required_masters = ['masterbias', 'masterflat']
 
@@ -417,7 +417,7 @@ class Andor(Instrument, metaclass=ABCMeta):
             result.save()
 
 
-class AndorT90(Andor):
+class AndorT90(OSNCCDCamera):
     
     name = "AndorT90"
     instrument_kw = "AndorT90"
@@ -446,7 +446,7 @@ class AndorT90(Andor):
         
         return super().build_wcs(reducedfit, *args, **kwargs)
 
-class AndorT150(Andor):
+class AndorT150(OSNCCDCamera):
         
     name = "AndorT150"
     instrument_kw = "Andor"
@@ -456,3 +456,15 @@ class AndorT150(Andor):
     gain_e_adu = 4.5
     field_width_arcmin = 7.92
     field_height_arcmin = 7.92
+
+
+class RoperT90(OSNCCDCamera):
+    name = "RoperT90"
+    instrument_kw = "RoperT90"
+    telescope = OSNT090.name
+
+    arcsec_per_pix = 0.387
+    gain_e_adu = 7.14
+    field_width_arcmin = 13.2
+    field_height_arcmin = 13.2
+

--- a/iop4lib/telescopes/telescope.py
+++ b/iop4lib/telescopes/telescope.py
@@ -168,7 +168,7 @@ class Telescope(metaclass=ABCMeta):
         if instrume_header == "RoperT90" and rawfit.epoch.night < datetime.datetime(2021, 10, 23):
             # RoperT90 was replaced by AndorT90 on 2021-10-23, but the control PC was not updated until some time later
             rawfit.instrument = INSTRUMENTS.RoperT90
-        elif instrume_header == "AndorT90" or (instrume_header == "RoperT90" and rawfit.epoch.night >= datetime.datetime(2021, 10, 23)):
+        elif instrume_header == "AndorT90" or (instrume_header == "RoperT90" and rawfit.epoch.night >= datetime.date(2021, 10, 23)):
             rawfit.instrument = INSTRUMENTS.AndorT90
         elif instrume_header == "Andor" or instrume_header == "AndorT150": # until 2023-01-11, AndorT150 was called simply Andor
             rawfit.instrument = INSTRUMENTS.AndorT150

--- a/iop4lib/telescopes/telescope.py
+++ b/iop4lib/telescopes/telescope.py
@@ -165,7 +165,7 @@ class Telescope(metaclass=ABCMeta):
 
         instrume_header = fits.getheader(rawfit.filepath, ext=0)["INSTRUME"] 
         
-        if instrume_header == "RoperT90" and rawfit.epoch.night < datetime.datetime(2021, 10, 23):
+        if instrume_header == "RoperT90" and rawfit.epoch.night < datetime.date(2021, 10, 23):
             # RoperT90 was replaced by AndorT90 on 2021-10-23, but the control PC was not updated until some time later
             rawfit.instrument = INSTRUMENTS.RoperT90
         elif instrume_header == "AndorT90" or (instrume_header == "RoperT90" and rawfit.epoch.night >= datetime.date(2021, 10, 23)):

--- a/iop4lib/telescopes/telescope.py
+++ b/iop4lib/telescopes/telescope.py
@@ -170,7 +170,7 @@ class Telescope(metaclass=ABCMeta):
             rawfit.instrument = INSTRUMENTS.RoperT90
         elif instrume_header == "AndorT90" or (instrume_header == "RoperT90" and rawfit.epoch.night >= datetime.datetime(2021, 10, 23)):
             rawfit.instrument = INSTRUMENTS.AndorT90
-        elif instrume_header == "Andor":
+        elif instrume_header == "Andor" or instrume_header == "AndorT150": # until 2023-01-11, AndorT150 was called simply Andor
             rawfit.instrument = INSTRUMENTS.AndorT150
         elif instrume_header == "CAFOS 2.2":
             rawfit.instrument = INSTRUMENTS.CAFOS

--- a/iop4lib/telescopes/telescope.py
+++ b/iop4lib/telescopes/telescope.py
@@ -18,6 +18,7 @@ from astropy.coordinates import Angle, SkyCoord
 import astrometry
 import numpy as np
 import math
+import datetime
 
 # iop4lib imports
 from iop4lib.enums import *
@@ -164,7 +165,10 @@ class Telescope(metaclass=ABCMeta):
 
         instrume_header = fits.getheader(rawfit.filepath, ext=0)["INSTRUME"] 
         
-        if instrume_header == "AndorT90":
+        if instrume_header == "RoperT90" and rawfit.epoch.night < datetime.datetime(2021, 10, 23):
+            # RoperT90 was replaced by AndorT90 on 2021-10-23, but the control PC was not updated until some time later
+            rawfit.instrument = INSTRUMENTS.RoperT90
+        elif instrume_header == "AndorT90" or (instrume_header == "RoperT90" and rawfit.epoch.night >= datetime.datetime(2021, 10, 23)):
             rawfit.instrument = INSTRUMENTS.AndorT90
         elif instrume_header == "Andor":
             rawfit.instrument = INSTRUMENTS.AndorT150


### PR DESCRIPTION
This PR adapts IOP4 to work on old data (2007-2021/2022):
 - Adds old CAFOS keywords that were not recognized.
 - Implements the old OSN T090 camera (RoperT90)
