### PR TITLE
Fix flags in web gui

### DIFF
--- a/iop4api/static/iop4api/gui.js
+++ b/iop4api/static/iop4api/gui.js
@@ -607,11 +607,11 @@ function flags_to_str(flags) {
         str_arr.push("not set");
     } 
           
-    if (flags & (1 << 0)) { // bad photometry
+    if (flags & (1 << 1)) { // bad photometry
         str_arr.push("bad photometry");
     }
           
-    if (flags & (1 << 1)) { // bad polarimetry
+    if (flags & (1 << 2)) { // bad polarimetry
         str_arr.push("bad polarimetry");
     }
 

--- a/iop4api/templates/iop4api/index.html
+++ b/iop4api/templates/iop4api/index.html
@@ -202,8 +202,8 @@
                         pointData['flagsstr'] = flags_to_str(pointData['flags']);
 
                         // to make it easier
-                        pointData['has_flag_bad_photometry'] = (pointData['flags'] & (1<<0));
-                        pointData['has_flag_bad_polarimetry'] = (pointData['flags'] & (1<<1));
+                        pointData['has_flag_bad_photometry'] = (pointData['flags'] & (1<<1));
+                        pointData['has_flag_bad_polarimetry'] = (pointData['flags'] & (1<<2));
 
                         return pointData;
                     });
@@ -222,17 +222,17 @@
                             notset = false;
                         }
 
-                        if (this.selected_plot_pts.every(pt => (pt['flags'] & (1<<0)))) {
+                        if (this.selected_plot_pts.every(pt => (pt['flags'] & (1<<1)))) {
                             bad_photometry = true;
-                        } else if (this.selected_plot_pts.some(pt => (pt['flags'] & (1<<0)))) {
+                        } else if (this.selected_plot_pts.some(pt => (pt['flags'] & (1<<1)))) {
                             bad_photometry = null;
                         } else {
                             bad_photometry = false;
                         }
 
-                        if (this.selected_plot_pts.every(pt => (pt['flags'] & (1<<1)))) {
+                        if (this.selected_plot_pts.every(pt => (pt['flags'] & (1<<2)))) {
                             bad_polarimetry = true;
-                        } else if (this.selected_plot_pts.some(pt => (pt['flags'] & (1<<1)))) {
+                        } else if (this.selected_plot_pts.some(pt => (pt['flags'] & (1<<2)))) {
                             bad_polarimetry = null;
                         } else {
                             bad_polarimetry = false;

--- a/iop4api/templates/iop4api/plot.html
+++ b/iop4api/templates/iop4api/plot.html
@@ -68,8 +68,8 @@
                             
                             <div class="col-12">
                                 <div class="row q-gutter-x-sm">
-                                    <q-checkbox v-model="selected_plot_pts_flagsummary.bad_photometry" @click="set_flag(1<<0, selected_plot_pts, !!selected_plot_pts_flagsummary.bad_photometry)" :disable="selected_plot_pts.length == 0" label="bad photometry" size="sm"></q-checkbox>
-                                    <q-checkbox v-model="selected_plot_pts_flagsummary.bad_polarimetry"  @click="set_flag(1<<1, selected_plot_pts, !!selected_plot_pts_flagsummary.bad_polarimetry)"  :disable="selected_plot_pts.length == 0" label="bad polarimetry" size="sm"></q-checkbox>
+                                    <q-checkbox v-model="selected_plot_pts_flagsummary.bad_photometry" @click="set_flag(1<<1, selected_plot_pts, !!selected_plot_pts_flagsummary.bad_photometry)" :disable="selected_plot_pts.length == 0" label="bad photometry" size="sm"></q-checkbox>
+                                    <q-checkbox v-model="selected_plot_pts_flagsummary.bad_polarimetry"  @click="set_flag(1<<2, selected_plot_pts, !!selected_plot_pts_flagsummary.bad_polarimetry)"  :disable="selected_plot_pts.length == 0" label="bad polarimetry" size="sm"></q-checkbox>
                                 </div>
                             </div>
                         </q-card-section>                          
@@ -104,8 +104,8 @@
                                     <td>[[ point.flags ]]</td>
                                     <!-- <td>[[ point.flagsstr ]]</td> -->
                                     <td>
-                                        <q-chip :selected="point.has_flag_bad_photometry" @click="toggle_flag(1<<0, [point])" color="black" text-color="white" :outline="!point.has_flag_bad_photometry">bad photometry</q-chip>
-                                        <q-chip :selected="point.has_flag_bad_polarimetry" @click="toggle_flag(1<<1, [point])" color="black" text-color="white" :outline="!point.has_flag_bad_polarimetry">bad polarimetry</q-chip>
+                                        <q-chip :selected="point.has_flag_bad_photometry" @click="toggle_flag(1<<1, [point])" color="black" text-color="white" :outline="!point.has_flag_bad_photometry">bad photometry</q-chip>
+                                        <q-chip :selected="point.has_flag_bad_polarimetry" @click="toggle_flag(1<<2, [point])" color="black" text-color="white" :outline="!point.has_flag_bad_polarimetry">bad polarimetry</q-chip>
                                     </td>
                                 </tr>
                             </tbody>

--- a/iop4api/views/plot.py
+++ b/iop4api/views/plot.py
@@ -222,15 +222,15 @@ def plot(request):
                                                      
                 let marker = "circle";
                                                                                           
-                if (xs[i] & (1 << 0)) { // bad photometry
+                if (xs[i] & (1 << 1)) { // bad photometry
                     marker = "triangle";
                 } 
 
-                if (xs[i] & (1 << 1)) { // bad polarimetry
+                if (xs[i] & (1 << 2)) { // bad polarimetry
                     marker = "inverted_triangle";
                 }
 
-                if ((xs[i] & (1 << 0)) && (xs[i] & (1 << 1))) { // bad photometry and polarimetry
+                if ((xs[i] & (1 << 1)) && (xs[i] & (1 << 2))) { // bad photometry and polarimetry
                     marker = "cross";                                 
                 }
                                                                                                                        


### PR DESCRIPTION
The flag gui was setting `bad photometry` as `1 << 0`; while the DB definition was `1 << 1`. This PR fixes the web gui to match the definition in `PhotoPolResult.FLAGS`.