### PR TITLE
fix tests in macOS

### DIFF
--- a/iop4lib/utils/parallel.py
+++ b/iop4lib/utils/parallel.py
@@ -210,6 +210,6 @@ def _parallel_relative_polarimetry_helper(keys, group):
         logger.info(f"Finished computing relative polarimetry for {group=}.")
 
 def parallel_relative_polarimetry(keys, groups):
-    with multiprocessing.Pool(iop4conf.nthreads) as pool:
+    mp_ctx = multiprocessing.get_context('fork') # fork is faster and does not need configuring again
+    with mp_ctx.Pool(iop4conf.nthreads) as pool:
         pool.starmap(_parallel_relative_polarimetry_helper, zip(keys, groups))
-


### PR DESCRIPTION
Tests in macOS were failing at the parallel polarimetry step:
```
INFO     iop4lib.db.epoch:epoch.py:634 <Epoch 2 | CAHA-T220/2022-09-18>: computing relative polarimetry over 1 polarimetry groups.
DEBUG    iop4lib.db.epoch:epoch.py:635 <Epoch 2 | CAHA-T220/2022-09-18>: groupkeys_L=[{'kwobj': '2200+420', 'instrument': 'CAFOS2.2', 'band': 'R', 'exptime': 10.0}]
Process SpawnPoolWorker-6:
Traceback (most recent call last):
  File "/Users/juan/miniconda3/envs/iop4/lib/python3.10/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/Users/juan/miniconda3/envs/iop4/lib/python3.10/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/juan/miniconda3/envs/iop4/lib/python3.10/multiprocessing/pool.py", line 114, in worker
    task = get()
  File "/Users/juan/miniconda3/envs/iop4/lib/python3.10/multiprocessing/queues.py", line 367, in get
    return _ForkingPickler.loads(res)
  File "/Users/juan/miniconda3/envs/iop4/lib/python3.10/site-packages/django/db/models/base.py", line 2477, in model_unpickle
    model = apps.get_model(*model_id)
  File "/Users/juan/miniconda3/envs/iop4/lib/python3.10/site-packages/django/apps/registry.py", line 201, in get_model
    self.check_models_ready()
  File "/Users/juan/miniconda3/envs/iop4/lib/python3.10/site-packages/django/apps/registry.py", line 143, in check_models_ready
    raise AppRegistryNotReady("Models aren't loaded yet.")
django.core.exceptions.AppRegistryNotReady: Models aren't loaded yet.
```
The reason was that the default method to create a new processes in macOS is spawn, but that requires configuring the ORM again. This sets explicitly the method to fork.

Now tests are passing locally both for macOS and linux.