### PR TITLE
Fix release title in docs deployment to GitHub pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Workaround for https://github.com/actions/checkout/issues/882
+        run: git fetch --tags --force origin
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This tries to fix #95, caused by a bug in the checkout action (github.com/actions/checkout/issues/882).