### PR TITLE
Simplify IOP4 and tests configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,19 +66,21 @@ jobs:
       - name: Install the package in editable mode with all additional dependencies
         run: pip install --editable .[all]
 
-      - name: Use mounted astrometry index files
-        run: |
-          ln -s /mnt/astrometry_cache $HOME/.astrometry_cache
-    
-      - name: Check astrometry index files were correctly mounted
-        run: ls $HOME/.astrometry_cache/5200/index-5200-00.fits
-
-      - name: Download test data
+      - name: Extract test data version from source code
         env:
           TEST_DATA_PASSWORD: ${{ secrets.test_data_password }}
-        run:  | 
+        run: |
           export TESTDATA_MD5SUM=`grep 'TESTDATA_MD5SUM' ./tests/conftest.py | awk -F"'" '{print $2}' | tr -d '\n'`
-          wget --post-data "pass=$TEST_DATA_PASSWORD" "https://vhega.iaa.es/iop4/iop4testdata.tar.gz?md5sum=$TESTDATA_MD5SUM" -O $HOME/iop4testdata.tar.gz
+
+      - name: Use mounted astrometry index files and test dataset
+        run: |
+          ln -s /mnt/astrometry_cache $HOME/.astrometry_cache
+          ln -s /mnt/test_datasets/iop4testdata.$TESTDATA_MD5SUM.tar.gz $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz 
+      
+      - name: Check that index files and test dataset were correctly mounted
+        run: |
+          ls -lh $HOME/.astrometry_cache/5200/index-5200-00.fits
+          ls -lh $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz
       
       - name: Run tests (with -o log_cli=true -o log_cli_level=DEBUG to debug CI actions)
         run: pytest -o log_cli=true -o log_cli_level=DEBUG -vxs tests
@@ -112,32 +114,34 @@ jobs:
           pip install -e .[doc]
           python -c 'import iop4lib; print(iop4lib.__version__)'
 
-      - name: Use mounted astrometry index files
-        run: |
-          ln -s /mnt/astrometry_cache $HOME/.astrometry_cache
-      
-      - name: Check astrometry index files were correctly mounted
-        run: ls $HOME/.astrometry_cache/5200/index-5200-00.fits
-
-      - name: Download test data
+      - name: Extract test data version from source code
         env:
           TEST_DATA_PASSWORD: ${{ secrets.test_data_password }}
         run: |
           export TESTDATA_MD5SUM=`grep 'TESTDATA_MD5SUM' ./tests/conftest.py | awk -F"'" '{print $2}' | tr -d '\n'`
-          wget --post-data "pass=$TEST_DATA_PASSWORD" "https://vhega.iaa.es/iop4/iop4testdata.tar.gz?md5sum=$TESTDATA_MD5SUM" -O $HOME/iop4testdata.tar.gz
+
+      - name: Use mounted astrometry index files and test dataset
+        run: |
+          ln -s /mnt/astrometry_cache $HOME/.astrometry_cache
+          ln -s /mnt/test_datasets/iop4testdata.$TESTDATA_MD5SUM.tar.gz $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz 
+      
+      - name: Check that index files and test dataset were correctly mounted
+        run: |
+          ls -lh $HOME/.astrometry_cache/5200/index-5200-00.fits
+          ls -lh $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz
 
       - name: Extract test data in the default data folder
         run: |
-          tar -xzf $HOME/iop4testdata.tar.gz -C $HOME
-          mv $HOME/iop4testdata $HOME/.iop4data  
+          tar -xzf $HOME/test_datasets/iop4testdata.$TESTDATA_MD5SUM.tar.gz -C $HOME
+          mv $HOME/iop4testdata.$TESTDATA_MD5SUM $HOME/iop4docsdata
 
       - name: Create the DB
         run: |
           python iop4site/manage.py makemigrations
           python iop4site/manage.py makemigrations iop4api
           python iop4site/manage.py migrate --no-input
-          python iop4site/manage.py loaddata $HOME/.iop4data/testcatalog.yaml
-          ls -lh $HOME/.iop4data/
+          python iop4site/manage.py loaddata $HOME/iop4testdata/testcatalog.yaml
+          ls -lh $HOME/iop4testdata/
 
       - name: Run iop4 on the test data
         run: iop4 --list-local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,16 +134,16 @@ jobs:
 
       - name: Extract test data in the default data folder
         run: |
-          tar -xzf $HOME/test_datasets/iop4testdata.$TESTDATA_MD5SUM.tar.gz -C $HOME
-          mv $HOME/iop4testdata.$TESTDATA_MD5SUM $HOME/iop4docsdata
+          tar -xzf $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz -C $HOME
+          mv $HOME/iop4testdata.$TESTDATA_MD5SUM $HOME/.iop4data
 
       - name: Create the DB
         run: |
           python iop4site/manage.py makemigrations
           python iop4site/manage.py makemigrations iop4api
           python iop4site/manage.py migrate --no-input
-          python iop4site/manage.py loaddata $HOME/iop4testdata/testcatalog.yaml
-          ls -lh $HOME/iop4testdata/
+          python iop4site/manage.py loaddata $HOME/.iop4data/testcatalog.yaml
+          ls -lh $HOME/.iop4data/
 
       - name: Run iop4 on the test data
         run: iop4 --list-local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Extract test data in the default data folder
         run: |
           tar -xzf $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz -C $HOME
-          mv $HOME/iop4testdata.$TESTDATA_MD5SUM $HOME/.iop4data
+          mv $HOME/iop4testdata $HOME/.iop4data
 
       - name: Create the DB
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           TEST_DATA_PASSWORD: ${{ secrets.test_data_password }}
         run: |
           export TESTDATA_MD5SUM=`grep 'TESTDATA_MD5SUM' ./tests/conftest.py | awk -F"'" '{print $2}' | tr -d '\n'`
+          echo "TESTDATA_MD5SUM=$TESTDATA_MD5SUM" >> $GITHUB_ENV
 
       - name: Use mounted astrometry index files and test dataset
         run: |
@@ -119,6 +120,7 @@ jobs:
           TEST_DATA_PASSWORD: ${{ secrets.test_data_password }}
         run: |
           export TESTDATA_MD5SUM=`grep 'TESTDATA_MD5SUM' ./tests/conftest.py | awk -F"'" '{print $2}' | tr -d '\n'`
+          echo "TESTDATA_MD5SUM=$TESTDATA_MD5SUM" >> $GITHUB_ENV
 
       - name: Use mounted astrometry index files and test dataset
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,24 +54,27 @@ jobs:
           pip install -e .[doc]
           python -c 'import iop4lib; print(iop4lib.__version__)'
 
-      - name: Use mounted astrometry index files
-        run: |
-          ln -s /mnt/astrometry_cache $HOME/.astrometry_cache
-      
-      - name: Check astrometry index files were correctly mounted
-        run: ls $HOME/.astrometry_cache/5200/index-5200-00.fits
-  
-      - name: Download test data
+      - name: Extract test data version from source code
         env:
           TEST_DATA_PASSWORD: ${{ secrets.test_data_password }}
         run: |
           export TESTDATA_MD5SUM=`grep 'TESTDATA_MD5SUM' ./tests/conftest.py | awk -F"'" '{print $2}' | tr -d '\n'`
-          wget --post-data "pass=$TEST_DATA_PASSWORD" "https://vhega.iaa.es/iop4/iop4testdata.tar.gz?md5sum=$TESTDATA_MD5SUM" -O $HOME/iop4testdata.tar.gz
+          echo "TESTDATA_MD5SUM=$TESTDATA_MD5SUM" >> $GITHUB_ENV
+
+      - name: Use mounted astrometry index files and test dataset
+        run: |
+          ln -s /mnt/astrometry_cache $HOME/.astrometry_cache
+          ln -s /mnt/test_datasets/iop4testdata.$TESTDATA_MD5SUM.tar.gz $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz 
+      
+      - name: Check that index files and test dataset were correctly mounted
+        run: |
+          ls -lh $HOME/.astrometry_cache/5200/index-5200-00.fits
+          ls -lh $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz
 
       - name: Extract test data in the default data folder
         run: |
-          tar -xzf $HOME/iop4testdata.tar.gz -C $HOME
-          mv $HOME/iop4testdata $HOME/.iop4data  
+          tar -xzf $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz -C $HOME
+          mv $HOME/iop4testdata.$TESTDATA_MD5SUM $HOME/.iop4data
 
       - name: Create the DB
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Extract test data in the default data folder
         run: |
           tar -xzf $HOME/iop4testdata.$TESTDATA_MD5SUM.tar.gz -C $HOME
-          mv $HOME/iop4testdata.$TESTDATA_MD5SUM $HOME/.iop4data
+          mv $HOME/iop4testdata $HOME/.iop4data
 
       - name: Create the DB
         run: |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you followed the steps in any of the two options above, you will have install
 
 ## Configuration
 
-After installation, take a look at the example configuration file (`config/config.example.yaml`), set the appropriate variables (path to the database, data directory, astrometry index files path, credentials, etc) and rename it to `config/config.yaml`.
+After installation, take a look at the example configuration file (`config/config.example.yaml`), set the appropriate variables (path to the database, data directory, astrometry index files path, credentials, etc) and save it to `~/.iop4.config.yaml`.
 
 ### Running Tests
 To run the tests, first follow the previous steps to configure IOP4. The test dataset will be automatically downloaded to your home directory

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ If you followed the steps in any of the two options above, you will have install
 
 ## Configuration
 
-After installation, take a look at the example configuration file (`config/config.example.yaml`), set the appropriate variables (path to the database, data directory, astrometry index files path, credentials, etc) and save it to `~/.iop4.config.yaml`.
+After installation, take a look at the example configuration file (`iop4lib/config.example.yaml`), set the appropriate variables (path to the database, data directory, astrometry index files path, credentials, etc) and save it to `~/.iop4.config.yaml`.
 
 ### Running Tests
 To run the tests, first follow the previous steps to configure IOP4. The test dataset will be automatically downloaded to your home directory
 ```bash
     $ pytest -vxs tests/
 ```
-If it is the first time executing IOP4, the astrometry index files will be downloaded to `astrometry_cache_path` (see `config/config.example.yaml`). This will take some time and a few tens of GB, depending on the exact version.
+If it is the first time executing IOP4, the astrometry index files will be downloaded to `astrometry_cache_path` (see `config.example.yaml`). This will take some time and a few tens of GB, depending on the exact version.
 
 **Warning**: in some macOS systems, the process [might hang up](https://github.com/juanep97/iop4/issues/14#issuecomment-1748465276). Execute `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` or add that line to your shell init script.
 

--- a/README.md
+++ b/README.md
@@ -149,10 +149,15 @@ iop4conf = iop4lib.Config(config_db=True, gonogui=False, jupytermode=True)
 ```
 
 ### Tips
-You can get an IPython interactive terminal after running iop4 using the `-i` option. You can override any config option using the `-o` option, e.g.:
+You can get an IPython interactive terminal after running iop4 using the `-i` option. You can override any config option using the `-o` option, e.g.
 ```bash
     $ iop4 -i -o nthreads=20 -o log_file=test.log --epoch-list T090/230313 T090/230317
 ```
+or by setting environment variables, e.g.
+```bash
+    $ IOP4_NTHREADS=20 IOP4_LOG_FILE=test.log iop4 -i --epoch-list T090/230313 T090/230317
+```
+Check `iop4 --help` for more info.
 
 ## Documentation
 To build and show the documentation, run

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you followed the steps in any of the two options above, you will have install
 After installation, take a look at the example configuration file (`config/config.example.yaml`), set the appropriate variables (path to the database, data directory, astrometry index files path, credentials, etc) and rename it to `config/config.yaml`.
 
 ### Running Tests
-To run the tests, first follow the previous steps to configure IOP4. At the moment, you will also need to download the `iop4testdata.tar.gz` file manually and place it under your home directory. Then, run
+To run the tests, first follow the previous steps to configure IOP4. The test dataset will be automatically downloaded to your home directory
 ```bash
     $ pytest -vxs tests/
 ```

--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -11,8 +11,7 @@ db_path: ~/.iop4data/iop4.db # Path to iop4 sqlite database file.
 astrometry_cache_path: ~/.astrometry_cache/ # <tr> Path to store the astromery index files.
 nthreads: 4 # <int> Number of threads / processes to use (e.g. 4).
 astrometry_timeout: 20 # <int> Timeout in minutes for astrometry solving.
-astrometry_allsky_allow: false # <bool> Whether to allow all sky searches in the astrometry.net solver. If there are many all-sky images and nthreads is too high, it might cause
-# very high memory consumption.
+astrometry_allsky_allow: false # <bool> Whether to allow all sky searches in the astrometry.net solver. If there are many all-sky images and nthreads is too high, it might cause very high memory consumption.
 astrometry_allsky_septhreshold: 25 # <int> Threshold of detected poinint mismatch to trigger an all-sky search.
 
 ################

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,10 +178,7 @@ def linkcode_resolve(domain, info):
     # Convert the file path to a GitHub URL
     repo_url = 'https://github.com/juanep97/iop4'
     if file_path.startswith(os.path.commonprefix([iop4conf.basedir, file_path])):
-        print(f"file_path: {file_path}")
-        print(f"basedir: {iop4conf.basedir}")
         rel_path = os.path.relpath(file_path, iop4conf.basedir)
-        print(f"rel_path: {rel_path}")
         url = f'{repo_url}/blob/{GIT_COMMIT_HASH}/{rel_path}'
         return url
     else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,8 @@ numpydoc_show_class_members = False
 # config_db=True as it needs to import the models.
 import os, sys, pathlib
 import iop4lib.config
-iop4conf = iop4lib.Config(config_path=pathlib.Path(iop4lib.config.Config.basedir) / "config.example.yaml", config_db=True)
+from importlib import resources
+iop4conf = iop4lib.Config(config_path=resources.files("iop4lib") / "config.example.yaml", config_db=True)
 import iop4lib.db
 
 # -- Add models' fields and their help_text to the documentation --

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ numpydoc_show_class_members = False
 import os, sys, pathlib
 sys.path.insert(0, os.path.abspath(os.path.join('..', 'iop4lib')))
 import iop4lib.config
-iop4conf = iop4lib.Config(config_path=pathlib.Path(iop4lib.config.Config.basedir) / "config" / "config.example.yaml", config_db=True)
+iop4conf = iop4lib.Config(config_path=pathlib.Path(iop4lib.config.Config.basedir) / "config.example.yaml", config_db=True)
 import iop4lib.db
 
 # -- Add models' fields and their help_text to the documentation --

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,6 @@ numpydoc_show_class_members = False
 # IMPORTANT! Config must use the example file, or you will show your credentials in the docs!
 # config_db=True as it needs to import the models.
 import os, sys, pathlib
-sys.path.insert(0, os.path.abspath(os.path.join('..', 'iop4lib')))
 import iop4lib.config
 iop4conf = iop4lib.Config(config_path=pathlib.Path(iop4lib.config.Config.basedir) / "config.example.yaml", config_db=True)
 import iop4lib.db

--- a/iop4api/templates/iop4api/about.html
+++ b/iop4api/templates/iop4api/about.html
@@ -6,19 +6,13 @@
     <p>
         IOP4, <i>the Interactive Photo-Polarimetric Python Pipeline</i>. 
         Check <a href="https://github.com/juanep97/iop4">the code in GitHub</a>. 
-        Documentation can be found at <a href="https://vhega.iaa.es/iop4/docs/">the VHEGA site</a>.
+        Documentation for the last version is hosted in <a href="https://juanep97.github.io/iop4/">GitHub Pages</a>.
     </p>
     
-    {% if debug %}
-        <p>
-            You can browse your local version of the docs at 
-            <a href="{% url 'iop4api:docs' %}">/iop4/docs/</a>
-            (you need to build it first with make <code>docs-sphinx</code>).
-        </p>
-    {% endif %}
-
     <p>
-        The test dataset can be downloaded at <a href="https://vhega.iaa.es/iop4/iop4testdata.tar.gz">this link</a>.
+        You can browse your local version of the docs at 
+        <a href="{% url 'iop4api:docs' %}">/iop4/docs/</a>
+        {% if debug %}(you need to build it first with make <code>docs-sphinx</code>).{% endif %}
     </p>
 
     {% if request.user.is_authenticated %}

--- a/iop4lib/config.example.yaml
+++ b/iop4lib/config.example.yaml
@@ -1,5 +1,5 @@
-# This is an example of the config file, copy it to config/config.yaml and edit it.
-# IOP4LIB will attempt to use config/config.yaml if it exists, otherwise it will use this one.
+# This is an example of the config file, copy it to ~/.iop4.config.yaml and edit it.
+# IOP4LIB will automatically attempt to use ~/.iop4.config.yaml if it exists, otherwise it will use this one.
 
 ###############
 ### GENERAL ###

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -127,6 +127,11 @@ class Config(dict):
         for k, v in config_dict.items():
             setattr(self, k, v)
 
+        # Override with config options in the environment
+        for k, v in os.environ.items():
+            if k.startswith("IOP4_") and k != "IOP4_CONFIG_FILE":
+                setattr(self, k[5:].lower(), v)
+
         # Override with config options passed as kwargs
 
         for k, v in kwargs.items():

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -1,7 +1,7 @@
 # other imports
 import os, yaml, logging
 from pathlib import Path
-from importlib.resources import files
+from importlib import resources
 import matplotlib, matplotlib.pyplot
 
 # Disable matplotlib logging except for warnings and above
@@ -113,7 +113,7 @@ class Config(dict):
                 elif Path("~/.iop4.config.yaml").expanduser().exists():
                     config_path = Path("~/.iop4.config.yaml").expanduser()
                 else:
-                    config_path = files("iop4lib") / "config.example.yaml"
+                    config_path = resources.files("iop4lib") / "config.example.yaml"
 
                 if not config_path.exists():
                     raise FileNotFoundError(f"Config file {config_path} not found.")
@@ -232,7 +232,7 @@ class Config(dict):
         with open(self.config_path, 'r') as f:
             config_dict = yaml.safe_load(f)
 
-        with open(files("iop4lib") / "config.example.yaml", 'r') as f:
+        with open(resources.files("iop4lib") / "config.example.yaml", 'r') as f:
             config_dict_example = yaml.safe_load(f)
 
         wrong = False

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -29,13 +29,6 @@ class Config(dict):
     r""" Configuration class for IOP4.
     
     This class is a singleton, that is, it always returns the same instance of the class.
-
-    .. note::
-        OSN_SourceList.txt contains the starting characters of the filenames of the sources in the OSN
-        repo. For each entry, it is loaded in the osn_fnames_patterns list as a regular 
-        expression (^<entry>.*\.fit(?:s+)$), where <entry> is the entry in the file. This will match any 
-        filename starting as the file entry and ending in either .fit or .fits.
-        
     """
 
     # PATH CONFIG

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -1,6 +1,7 @@
 # other imports
 import os, yaml, logging
 from pathlib import Path
+from importlib.resources import files
 import matplotlib, matplotlib.pyplot
 
 # Disable matplotlib logging except for warnings and above
@@ -112,7 +113,7 @@ class Config(dict):
                 elif Path("~/.iop4.config.yaml").expanduser().exists():
                     config_path = Path("~/.iop4.config.yaml").expanduser()
                 else:
-                    config_path = Path(self.basedir) / "config" / "config.example.yaml"
+                    config_path = files("iop4lib") / "config" / "config.example.yaml"
 
                 if not config_path.exists():
                     raise FileNotFoundError(f"Config file {config_path} not found.")
@@ -231,7 +232,7 @@ class Config(dict):
         with open(self.config_path, 'r') as f:
             config_dict = yaml.safe_load(f)
 
-        with open(Path(self.basedir) / "config" / "config.example.yaml", 'r') as f:
+        with open(files("iop4lib") / "config" / "config.example.yaml", 'r') as f:
             config_dict_example = yaml.safe_load(f)
 
         wrong = False

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -112,7 +112,7 @@ class Config(dict):
                 elif Path("~/.iop4.config.yaml").expanduser().exists():
                     config_path = Path("~/.iop4.config.yaml").expanduser()
                 else:
-                    config_path = Path(self.basedir) / "config" / "config.yaml"
+                    config_path = Path(self.basedir) / "config" / "config.example.yaml"
 
                 if not config_path.exists():
                     raise FileNotFoundError(f"Config file {config_path} not found.")

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -113,7 +113,7 @@ class Config(dict):
                 elif Path("~/.iop4.config.yaml").expanduser().exists():
                     config_path = Path("~/.iop4.config.yaml").expanduser()
                 else:
-                    config_path = files("iop4lib") / "config" / "config.example.yaml"
+                    config_path = files("iop4lib") / "config.example.yaml"
 
                 if not config_path.exists():
                     raise FileNotFoundError(f"Config file {config_path} not found.")
@@ -232,7 +232,7 @@ class Config(dict):
         with open(self.config_path, 'r') as f:
             config_dict = yaml.safe_load(f)
 
-        with open(files("iop4lib") / "config" / "config.example.yaml", 'r') as f:
+        with open(files("iop4lib") / "config.example.yaml", 'r') as f:
             config_dict_example = yaml.safe_load(f)
 
         wrong = False

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -1,6 +1,6 @@
 # other imports
-import os, pathlib, yaml, logging
-
+import os, yaml, logging
+from pathlib import Path
 import matplotlib, matplotlib.pyplot
 
 # Disable matplotlib logging except for warnings and above
@@ -33,7 +33,7 @@ class Config(dict):
 
     # PATH CONFIG
 
-    basedir = pathlib.Path(__file__).parents[1].absolute()
+    basedir = Path(__file__).parents[1].absolute()
 
     # ALL OTHER CONFIG OPTIONS READ FROM SEPARATE CONFIG FILE (see config.example.yaml)
 
@@ -101,12 +101,16 @@ class Config(dict):
             if hasattr(self, 'config_path') and self.config_path is not None:
                 config_path = self.config_path
             else:
-                config_path = pathlib.Path(self.basedir) / "config" / "config.yaml"
+
+                if (config_path := os.getenv("IOP4_CONFIG_FILE")) is not None:
+                    config_path = Path(config_path).expanduser()
+                else:
+                    config_path = Path("~/.iop4.config.yaml").expanduser()
 
                 if not config_path.exists():
-                    config_path = pathlib.Path(self.basedir) / "config" / "config.example.yaml"
+                    config_path = Path(self.basedir) / "config" / "config.example.yaml"
         
-        self.config_path = config_path
+        self.config_path = Path(config_path).expanduser()
 
         # Load config file and set attributes
 
@@ -125,7 +129,7 @@ class Config(dict):
 
         for k, v in self.items():
             if (k in ['basedir', 'datadir', 'log_file'] or 'path' in k) and v is not None: # config variables should have ~ expanded
-                setattr(self, k, str(pathlib.Path(v).expanduser()))
+                setattr(self, k, str(Path(v).expanduser()))
 
         # If data dir does not exist, create it
         
@@ -215,7 +219,7 @@ class Config(dict):
         with open(self.config_path, 'r') as f:
             config_dict = yaml.safe_load(f)
 
-        with open(pathlib.Path(self.basedir) / "config" / "config.example.yaml", 'r') as f:
+        with open(Path(self.basedir) / "config" / "config.example.yaml", 'r') as f:
             config_dict_example = yaml.safe_load(f)
 
         wrong = False

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -168,20 +168,9 @@ class Config(dict):
         from django.conf import settings
         from django.apps import apps
         
-        #import sys
-        #sys.path.append(r"/path/to/iop4/iop4site/")
-        #not necessary anymore, now app is a module.
         settings.configure(
             INSTALLED_APPS=[
                 'iop4api',
-                # # apps below not necessary for iop4lib but allows using User model from the iop4.py -i shell 
-                # # (python manage.py shell includes this by default, since it uses the settings in iop4site.settings)
-                # "iop4site.iop4site.apps.IOP4AdminConfig", 
-                # "django.contrib.auth", 
-                # "django.contrib.contenttypes",
-                # "django.contrib.sessions",
-                # "django.contrib.messages",
-                # "django.contrib.staticfiles",
             ],
             DATABASES = {
                 "default": {

--- a/iop4lib/config.py
+++ b/iop4lib/config.py
@@ -100,7 +100,7 @@ class Config(dict):
     
         Config._configured = True
 
-        # If config_path is None, either use already in use or the default ones
+        # If config_path is None, either use the one already in use or the default one
 
         if config_path is None:
             if hasattr(self, 'config_path') and self.config_path is not None:

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -15,31 +15,11 @@ you would invoke iop4 as `iop4 -o log_level=DEBUG -o n_processes=6 [other option
 Contact: Juan Escudero Pedrosa (jescudero@iaa.es).
 """
 
-# iop4lib config
-import iop4lib.config
-iop4conf = iop4lib.Config(config_db=True)
-
-#other imports
 import os
 import sys
 import argparse
 import coloredlogs
-import numpy as np
-import scipy as sp
-import pandas as pd
-import matplotlib as mplt
-import matplotlib.pyplot as plt
-import itertools
-from astropy.time import Time
 import datetime
-import time
-from pathlib import Path
-
-# iop4lib imports
-from iop4lib.db import *
-from iop4lib.enums import *
-from iop4lib.telescopes import *
-from iop4lib.instruments import *
 
 # logging
 import logging
@@ -48,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 
 def process_epochs(epochname_list, force_rebuild, check_remote_list):
+    from iop4lib.db import Epoch, RawFit, PhotoPolResult
+    from iop4lib.enums import IMGTYPES, OBSMODES
 
     epoch_L  : list[Epoch] = list()
     
@@ -102,7 +84,9 @@ def process_epochs(epochname_list, force_rebuild, check_remote_list):
 
 
 def list_local_epochnames():
-    """ List all local epochnames in local archives (by looking at the raw directory)."""
+    """List all local epochnames in local archives (by looking at the raw directory)."""
+
+    from iop4lib.telescopes import Telescope
 
     local_epochnames = list()
 
@@ -113,8 +97,10 @@ def list_local_epochnames():
     return local_epochnames
     
 def list_remote_epochnames():
-    """ List all remote epochnames in remote archives.
-    """
+    """List all remote epochnames in remote archives."""
+
+    from iop4lib.telescopes import Telescope
+
     epochnames = list()
 
     for tel_cls in Telescope.get_known():
@@ -124,17 +110,19 @@ def list_remote_epochnames():
 
 
 def discover_missing_epochs():
-    """ Discover missing epochs in remote archive."""
+    """Discover missing epochs in remote archive."""
     return list(set(list_remote_epochnames()).difference(list_local_epochnames()))    
 
 
 def list_remote_filelocs(epochnames: None | list[str] = None):
-    """ Discover files in remote archive for the given epochs.
+    """Discover files in remote archive for the given epochs.
     
     Use this function to list all files in the remote archive for the given epochs.
     It avoids calling list_remote_raw_fnames() for each epoch.
     """
     
+    from iop4lib.telescopes import Telescope
+
     if epochnames is None:
          epochnames = list_remote_epochnames()
 
@@ -149,7 +137,9 @@ def list_remote_filelocs(epochnames: None | list[str] = None):
     return filelocs
 
 def list_local_filelocs():
-    """ Discover local filelocs in local archive."""
+    """Discover local filelocs in local archive."""
+
+    from iop4lib.telescopes import Telescope
 
     local_filelocs = list()
 
@@ -172,6 +162,7 @@ def discover_missing_filelocs():
 
 
 def retry_failed_files():
+    from iop4lib.db import ReducedFit, Epoch
     qs = ReducedFit.objects.filter(flags__has=ReducedFit.FLAGS.ERROR_ASTROMETRY).all()
     logger.info(f"Retrying {qs.count()} failed reduced fits.")
     Epoch.reduce_reducedfits(qs)
@@ -181,6 +172,8 @@ def retry_failed_files():
 
 
 def filter_epochname_by_date(epochname_list, date_start=None, date_end=None):
+    from iop4lib.db import Epoch
+
     if date_start is not None:
         epochname_list = [epochname for epochname in epochname_list if Epoch.epochname_to_tel_night(epochname)[1] >= datetime.date.fromisoformat(date_start)]
     
@@ -190,6 +183,7 @@ def filter_epochname_by_date(epochname_list, date_start=None, date_end=None):
     return epochname_list
 
 def filter_filelocs_by_date(fileloc_list, date_start=None, date_end=None):
+    from iop4lib.db import RawFit
 
     if date_start is not None:
         fileloc_list = [fileloc for fileloc in fileloc_list if RawFit.fileloc_to_tel_night_filename(fileloc)[1] >= datetime.date.fromisoformat(date_start)]
@@ -201,16 +195,20 @@ def filter_filelocs_by_date(fileloc_list, date_start=None, date_end=None):
 
 
 def group_epochnames_by_telescope(epochnames):
-    
-        epochnames_by_telescope = {tel_cls.name:list() for tel_cls in Telescope.get_known()}
-    
-        for epochname in epochnames:
-            tel, night = Epoch.epochname_to_tel_night(epochname)
-            epochnames_by_telescope[tel].append(epochname)
-    
-        return epochnames_by_telescope
+    from iop4lib.db import Epoch
+    from iop4lib.telescopes import Telescope
+
+    epochnames_by_telescope = {tel_cls.name:list() for tel_cls in Telescope.get_known()}
+
+    for epochname in epochnames:
+        tel, night = Epoch.epochname_to_tel_night(epochname)
+        epochnames_by_telescope[tel].append(epochname)
+
+    return epochnames_by_telescope
 
 def group_filelocs_by_telescope(filelocs):
+    from iop4lib.db import RawFit
+    from iop4lib.telescopes import Telescope
 
     filelocs_by_telescope = {tel_cls.name:list() for tel_cls in Telescope.get_known()}
 
@@ -252,8 +250,9 @@ def main():
     
     parser.add_argument('-i', "--interactive", dest="interactive", action="store_true", help="<Optional> Jump to an IPython shell after finishing execution")
     parser.add_argument('--check-config', action="store_true", help="<Optional> Check the current configuration and exit")
+    parser.add_argument('--config-file', dest='config_file', default=None, help="<Optional> Path to the config file to use. By default, IOP4 will try to use (in order) the file in IOP4_CONFIG_FILE env var, ~/.iop4.config.yaml, or the the example config file.")
     parser.add_argument('-o', action='append', dest='config_overrides', help="Override a config option (e.g., -o option=value)")
-    
+
     # epoch processing options
     parser.add_argument('--epoch-list', dest='epochname_list', nargs='+', help='<Optional> List of epochs (e.g: T090/230102 T090/230204)')
     parser.add_argument('--discover-missing', action='store_true', help='<Optional> Discover new epochs to process them')
@@ -287,6 +286,15 @@ def main():
 
     # Configuration:
 
+    global iop4conf
+    import iop4lib.config
+    iop4conf = iop4lib.Config(config_path=args.config_file, config_db=True)
+
+    print("Using config file:", iop4conf.config_path)
+    
+    from iop4lib.db import Epoch, RawFit
+    from iop4lib.telescopes import Telescope
+
     if args.config_overrides:
         # get the config options as a dict
         opts = parse_config_overrides(args.config_overrides)
@@ -294,10 +302,10 @@ def main():
         iop4conf.update(opts)
 
     if not iop4conf.is_valid():
-        print("check_config: there are some missing keys in the config file. All keys in the example config file must be present. Add them to your config file (you can set them to null) and try again. Aborting.")
+        print("There are some missing keys in the config file. All keys in the example config file must be present. Add them to your config file (you can set them to null) and try again. Aborting.")
         sys.exit(-1)
     elif args.check_config:
-        print("check_config: config file is OK.")
+        print("Config file is OK.")
         sys.exit(0)
 
     ## configure logging

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -2,15 +2,26 @@
 """ iop4.py
     Invoke the IOP4 pipeline.
 
-You can specify how to select epochs using the --epoch-list, --discover-missing and --list-local options.
-You can check whether to keep selected epochs that are already in DB using the --no-check-db option, otherwise
-they will be removed from the list of epochs to process. The --date-start and --date-end options allow to filter
-the selected epochs by date. 
+You can specify how to select epochs using the --epoch-list, --discover-missing 
+and --list-local options. You can check whether to keep selected epochs that are 
+already in DB using the --no-check-db option, otherwise they will be removed 
+from the list of epochs to process. The --date-start and --date-end options 
+allow to filter the selected epochs by date. 
 
 Equivalent options exist for files.
 
-Use -o option=value to override config options, e.g., to set the log level to DEBUG and use 6 parallel processes, 
-you would invoke iop4 as `iop4 -o log_level=DEBUG -o n_processes=6 [other options]`.
+You can override config options with environment variables, e.g., 
+`IOP4_LOG_LEVEL=DEBUG iop4 [other options]`. This will work for any process 
+using iop4lib (i.e., iop4 main script, API, etc.). E.g. to set the log level to
+DEBUG, you would invoke iop4 as `IOP4_LOG_LEVEL=DEBUG iop4 [other options]`. 
+Options set with environment variables will take precedence over config file 
+options.
+
+You can also use -o option=value to override config options, e.g., to set the 
+log level to DEBUG and use 6 parallel processes, you would invoke iop4 as 
+`iop4 -o log_level=DEBUG -o n_processes=6 [other options]`. This will work only 
+for the iop4 main script. Options set with -o will take precedence over any 
+other configuration method.
 
 Contact: Juan Escudero Pedrosa (jescudero@iaa.es).
 """

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -36,9 +36,11 @@ import datetime
 import logging
 logger = logging.getLogger(__name__)
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing import Sequence, Iterable
 
-
-def process_epochs(epochname_list, force_rebuild, check_remote_list):
+def process_epochs(epochname_list: Iterable[str], force_rebuild: bool, check_remote_list: bool):
     from iop4lib.db import Epoch, RawFit, PhotoPolResult
     from iop4lib.enums import IMGTYPES, OBSMODES
 
@@ -94,7 +96,7 @@ def process_epochs(epochname_list, force_rebuild, check_remote_list):
     logger.info("Done.")
 
 
-def list_local_epochnames():
+def list_local_epochnames() -> list[str]:
     """List all local epochnames in local archives (by looking at the raw directory)."""
 
     from iop4lib.telescopes import Telescope
@@ -107,7 +109,7 @@ def list_local_epochnames():
 
     return local_epochnames
     
-def list_remote_epochnames():
+def list_remote_epochnames() -> list[str]:
     """List all remote epochnames in remote archives."""
 
     from iop4lib.telescopes import Telescope
@@ -120,12 +122,12 @@ def list_remote_epochnames():
     return epochnames
 
 
-def discover_missing_epochs():
+def discover_missing_epochs() -> list[str]:
     """Discover missing epochs in remote archive."""
     return list(set(list_remote_epochnames()).difference(list_local_epochnames()))    
 
 
-def list_remote_filelocs(epochnames: None | list[str] = None):
+def list_remote_filelocs(epochnames: Sequence[str] = None) -> list[str]:
     """Discover files in remote archive for the given epochs.
     
     Use this function to list all files in the remote archive for the given epochs.
@@ -147,7 +149,7 @@ def list_remote_filelocs(epochnames: None | list[str] = None):
 
     return filelocs
 
-def list_local_filelocs():
+def list_local_filelocs() -> list[str]:
     """Discover local filelocs in local archive."""
 
     from iop4lib.telescopes import Telescope
@@ -161,7 +163,7 @@ def list_local_filelocs():
 
     return local_filelocs
 
-def discover_missing_filelocs():
+def discover_missing_filelocs() -> list[str]:
     """ Discover missing files in remote archive.
 
     Compares the lists of remote files with the list of local files and returns the fileloc of the missing files.
@@ -182,7 +184,7 @@ def retry_failed_files():
 
 
 
-def filter_epochname_by_date(epochname_list, date_start=None, date_end=None):
+def filter_epochname_by_date(epochname_list: Sequence[str], date_start: str = None, date_end: str = None) -> list[str]:
     from iop4lib.db import Epoch
 
     if date_start is not None:
@@ -193,7 +195,7 @@ def filter_epochname_by_date(epochname_list, date_start=None, date_end=None):
     
     return epochname_list
 
-def filter_filelocs_by_date(fileloc_list, date_start=None, date_end=None):
+def filter_filelocs_by_date(fileloc_list: Iterable[str], date_start: str = None, date_end: str = None) -> list[str]:
     from iop4lib.db import RawFit
 
     if date_start is not None:
@@ -205,7 +207,7 @@ def filter_filelocs_by_date(fileloc_list, date_start=None, date_end=None):
     return fileloc_list
 
 
-def group_epochnames_by_telescope(epochnames):
+def group_epochnames_by_telescope(epochnames: Iterable[str]) -> dict[str, list[str]]:
     from iop4lib.db import Epoch
     from iop4lib.telescopes import Telescope
 
@@ -217,7 +219,7 @@ def group_epochnames_by_telescope(epochnames):
 
     return epochnames_by_telescope
 
-def group_filelocs_by_telescope(filelocs):
+def group_filelocs_by_telescope(filelocs: Iterable[str]) -> dict[str, list[str]]:
     from iop4lib.db import RawFit
     from iop4lib.telescopes import Telescope
 
@@ -230,7 +232,7 @@ def group_filelocs_by_telescope(filelocs):
     return filelocs_by_telescope
 
 
-def parse_config_overrides(overrides):
+def parse_config_overrides(overrides: Iterable[str]) -> dict:
 
     config = dict()
 

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -36,9 +36,7 @@ import datetime
 import logging
 logger = logging.getLogger(__name__)
 
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from typing import Sequence, Iterable
+from typing import Sequence, Iterable
 
 def process_epochs(epochname_list: Iterable[str], force_rebuild: bool, check_remote_list: bool):
     from iop4lib.db import Epoch, RawFit, PhotoPolResult

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ include = ["iop4*"]
 exclude = ["iop4lib._dev_version"]
 
 [tool.setuptools.package-data]
-iop4lib = ["config/config.example.yaml", 
+iop4lib = ["iop4lib/config.example.yaml", 
            "iop4lib/instruments/dipol_astrometry.yaml",
            "iop4lib/utils/host_correction_data.csv"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,11 @@ import yaml
 import hashlib
 from pathlib import Path
 
-TEST_CONFIG = str(Path(iop4conf.datadir) / "config.tests.yaml")
 TESTDATA_FPATH = str(Path("~/iop4testdata.tar.gz").expanduser())
+TEST_CONFIG = str(Path("~/iop4testdata/config.tests.yaml").expanduser())
+TEST_DATADIR = str(Path("~/iop4testdata").expanduser())
 TESTDATA_MD5SUM = '4d393377f8c659e2ead2fa252a9a38b2'
-TEST_DATADIR = str(Path(iop4conf.datadir) / "iop4testdata")
-TEST_DB_PATH = str(Path(iop4conf.db_path).expanduser().parent / ("test_" + str(Path(iop4conf.db_path).name)))
+TEST_DB_PATH = str(Path("~/iop4testdata/test.db").expanduser())
 
 def pytest_configure():
 
@@ -62,7 +62,7 @@ def setUpClass():
         raise Exception(f"Error creating test data directory: {e}")
     
     # unpack test data
-    if os.system(f"tar -xzf {TESTDATA_FPATH} -C {Path(iop4conf.datadir).parent}") != 0:
+    if os.system(f"tar -xzf {TESTDATA_FPATH} -C {str(Path(TEST_DATADIR).parent)}") != 0:
         raise Exception("Error unpacking test dataset")
     
     # create test config file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ import hashlib
 from pathlib import Path
 
 TESTDATA_MD5SUM = '4d393377f8c659e2ead2fa252a9a38b2'
-TESTDATA_FPATH = str(Path("~/iop4testdata.{TESTDATA_MD5SUM}.tar.gz").expanduser())
+TESTDATA_FPATH = str(Path(f"~/iop4testdata.{TESTDATA_MD5SUM}.tar.gz").expanduser())
 TEST_CONFIG = str(Path("~/iop4testdata/config.tests.yaml").expanduser())
 TEST_DATADIR = str(Path("~/iop4testdata").expanduser())
 TEST_DB_PATH = str(Path("~/iop4testdata/test.db").expanduser())
@@ -83,7 +83,7 @@ def setUpClass():
         raise Exception(f"Error creating test data directory: {e}")
     
     # unpack test data
-    if os.system(f"tar -xzf {TESTDATA_FPATH} -C {str(Path(TEST_DATADIR).parent)}") != 0:
+    if os.system(f"tar -xzf {TESTDATA_FPATH} -C {Path(TEST_DATADIR).parent}") != 0:
         raise Exception("Error unpacking test dataset")
     
     # create test config file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,23 @@
+""" Configuration for pytest tests.
+
+Django pytest tests require giving the real database path. Also, we would like 
+to use the configured astrometry index files path, if it was already configured 
+in the system were tests are being run, to avoid downloading them again 
+unnecessarily.
+
+The configuration involves reading the real IOP4 config, changing the datadir 
+and database paths to the test ones, and creating a test config file. It will 
+also check that the right version of the test dataset is available and unpack 
+it. Test submodules must be configured to use the created test config file, e.g. 
+with
+```
+import iop4lib.config
+iop4conf = iop4lib.Config(config_path=TEST_CONFIG)
+```
+
+The test datadir is removed after the tests are run.
+"""
+
 # iop4lib config
 import iop4lib.config
 iop4conf = iop4lib.Config(config_db=False)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -65,4 +65,5 @@ def test_host_correction_data_load(load_test_catalog):
 def test_iop4_script():
     """ Test that the iop4 script is available """
     import subprocess
-    assert subprocess.run(["iop4", "--help"]).returncode == 0
+    assert subprocess.run(["iop4", "--help"]).returncode == 0, "iop4 help invokation"
+    assert subprocess.run(["iop4", "--check-config"]).returncode == 0, "iop4 configuration check"

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -35,7 +35,7 @@ def test_testconfig_testdb(load_test_catalog):
     assert (hasattr(iop4conf, "config_path"))
     assert (Path(iop4conf.datadir).name == "iop4testdata")
     assert (Path(iop4conf.config_path).name == "config.tests.yaml")
-    assert ("test_" in Path(iop4conf.db_path).name)
+    assert ("test" in Path(iop4conf.db_path).name)
     assert (Epoch.objects.count() == 0)
     assert (RawFit.objects.count() == 0)
     assert (ReducedFit.objects.count() == 0)

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -60,3 +60,9 @@ def test_host_correction_data_load(load_test_catalog):
     assert val is not None
     assert val == approx(1.18)
     assert err == approx(0.06)
+
+@pytest.mark.django_db(transaction=True)
+def test_iop4_script():
+    """ Test that the iop4 script is available """
+    import subprocess
+    assert subprocess.run(["iop4", "--help"]).returncode == 0


### PR DESCRIPTION
- Allow specifying a different configuration file and overriding config options, both with environment variables (for all iop4lib-related processes) and with `-o` options to the `iop4` command (which takes preference).
- Simplify test configuration by using `~/iop4testdata` as path.
- Work only with the test dataset that indicates the right version in the filename (`iop4testdata.{{md5}}.tar.gz`), save time skipping the md5 sum check (~1-2min).
- Automatically download test dataset if needed.
- The CI workflows now use the test dataset file provided by the runner, in the same way as the astrometry index files are provided, which saves some time (~1-2min).