### PR TITLE
Fix unintended line wrap in night summary

### DIFF
--- a/iop4lib/iop4_night_summary.html
+++ b/iop4lib/iop4_night_summary.html
@@ -76,8 +76,7 @@
                             </td>
                             <td>
                                 {% for srcname in epoch.srcname_list %}
-                                    {{ srcname }}
-                                    {% if not forloop.last %}, {% endif %}
+                                    {{ srcname }}{% if not forloop.last %}, {% endif %}
                                 {% endfor %}
                             </td>
                         </tr>


### PR DESCRIPTION
Avoid this in the night summary 
<img width="126" alt="imagen" src="https://github.com/juanep97/iop4/assets/26815511/feef1bd8-3cbc-43c1-b320-a2d4c7e3e851">
