### PR TITLE
Tests for the web interface

### DIFF
--- a/iop4api/templates/iop4api/about.html
+++ b/iop4api/templates/iop4api/about.html
@@ -9,11 +9,13 @@
         Documentation for the last version is hosted in <a href="https://juanep97.github.io/iop4/">GitHub Pages</a>.
     </p>
     
-    <p>
-        You can browse your local version of the docs at 
-        <a href="{% url 'iop4api:docs' %}">/iop4/docs/</a>
-        {% if debug %}(you need to build it first with make <code>docs-sphinx</code>).{% endif %}
-    </p>
+    {% if debug %}
+        <p>
+            You can browse your local version of the docs at 
+            <a href="{% url 'iop4api:docs' %}">/iop4/docs/</a>
+            (you need to build it first with make <code>docs-sphinx</code>).
+        </p>
+    {% endif %}
 
     {% if request.user.is_authenticated %}
         <p class="styled-box">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ def pytest_configure():
             }
         },
         DEBUG = False,
+        SECRET_KEY = "fake-test-key",
     )
     
     iop4conf.configure(db_path=TEST_DB_PATH, datadir=TEST_DATADIR)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,31 @@
+import pytest
+from .conftest import TEST_CONFIG
+
+# iop4lib config
+import iop4lib.config
+iop4conf = iop4lib.Config(config_path=TEST_CONFIG)
+
+# other imports
+import re
+from pathlib import Path
+from django.test import client
+from django.test import override_settings
+
+# logging
+import logging
+logger = logging.getLogger(__name__)
+
+# we need to make iop4site module as iop4site, not as iop4site.iop4site
+# we also need to load all the rest of settings that we usually don't use
+import sys
+sys.path.insert(0, str(Path(__file__).parents[1] / "iop4site/"))
+import iop4site.settings
+settings_dict = {key:value for key,value in vars(iop4site.settings).items() if re.match(r'^[A-Z][A-Z_0-9]*$', key)}
+settings_dict["ALLOWED_HOSTS"] = ['testserver']
+
+@override_settings(**settings_dict)
+def test_index(client):
+    """Test the index page"""
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"Juan Escudero Pedrosa" in response.content

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -15,7 +15,7 @@ from django.test import override_settings
 import logging
 logger = logging.getLogger(__name__)
 
-# we need to make iop4site module as iop4site, not as iop4site.iop4site
+# we need to make iop4site module available as iop4site, not as iop4site.iop4site
 # we also need to load all the rest of settings that we usually don't use
 import sys
 sys.path.insert(0, str(Path(__file__).parents[1] / "iop4site/"))

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -21,6 +21,8 @@ import sys
 sys.path.insert(0, str(Path(__file__).parents[1] / "iop4site/"))
 import iop4site.settings
 settings_dict = {key:value for key,value in vars(iop4site.settings).items() if re.match(r'^[A-Z][A-Z_0-9]*$', key)}
+# We want to test the production scenario
+settings_dict["DEBUG"] = False
 settings_dict["ALLOWED_HOSTS"] = ['testserver']
 
 @override_settings(**settings_dict)


### PR DESCRIPTION
In this PR:
- Bug fix: the index page template was requesting the reverse for `iop4api:docs` in production too, but this only exists in debug mode.
- Add tests for the web interface. At the moment, it only checks that the index page can be viewed (i.e. we don't get an error immediately).