### PR TITLE
iop4.py: simplify cli options

### DIFF
--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -39,16 +39,6 @@ logger = logging.getLogger(__name__)
 from typing import Sequence, Iterable
 
 def process_epochs(epochname_list: Iterable[str], args):
-    """Process the given epochnames.
-
-    This includes registering the epochs in the database, building the master 
-    calibration files, reducing the science files, computing the photometry and
-    polarimetry results, and applying the host galaxy correction.
-
-    Since epochs are processed whole, previous photo-polarimetric results for 
-    the given epochs will be deleted beforehand.
-    """
-
     from iop4lib.db import Epoch, RawFit, PhotoPolResult
     from iop4lib.enums import IMGTYPES, OBSMODES
 

--- a/iop4lib/iop4.py
+++ b/iop4lib/iop4.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 from typing import Sequence, Iterable
 
-def process_epochs(epochname_list: Iterable[str], force_rebuild: bool, check_remote_list: bool):
+def process_epochs(epochname_list: Iterable[str], args):
     from iop4lib.db import Epoch, RawFit, PhotoPolResult
     from iop4lib.enums import IMGTYPES, OBSMODES
 
@@ -47,30 +47,30 @@ def process_epochs(epochname_list: Iterable[str], force_rebuild: bool, check_rem
     logger.info("Epochs will be created.")
 
     for epochname in epochname_list:
-        epoch = Epoch.create(epochname=epochname, check_remote_list=check_remote_list)
+        epoch = Epoch.create(epochname=epochname, check_remote_list=~args.skip_remote_file_list)
         epoch_L.append(epoch)
 
     logger.info("Creating Master Biases")
 
     for epoch in epoch_L:
         
-        epoch.build_master_biases(force_rebuild=force_rebuild)
+        epoch.build_master_biases(force_rebuild=args.force_rebuild)
 
     logger.info("Creating Master Darks.")
 
     for epoch in epoch_L:
-        epoch.build_master_darks(force_rebuild=force_rebuild)
+        epoch.build_master_darks(force_rebuild=args.force_rebuild)
         
     logger.info("Creating Master Flats.")
 
     for epoch in epoch_L:
-        epoch.build_master_flats(force_rebuild=force_rebuild)
+        epoch.build_master_flats(force_rebuild=args.force_rebuild)
 
     logger.info("Science files will be reduced.")
 
     rawfits = RawFit.objects.filter(epoch__in=epoch_L, imgtype=IMGTYPES.LIGHT).all()
-    Epoch.reduce_rawfits(rawfits.filter(obsmode=OBSMODES.PHOTOMETRY), force_rebuild=force_rebuild)
-    Epoch.reduce_rawfits(rawfits.filter(obsmode=OBSMODES.POLARIMETRY), force_rebuild=force_rebuild)
+    Epoch.reduce_rawfits(rawfits.filter(obsmode=OBSMODES.PHOTOMETRY), force_rebuild=args.force_rebuild)
+    Epoch.reduce_rawfits(rawfits.filter(obsmode=OBSMODES.POLARIMETRY), force_rebuild=args.force_rebuild)
 
     logger.info("Computing results.")
 
@@ -92,6 +92,51 @@ def process_epochs(epochname_list: Iterable[str], force_rebuild: bool, check_rem
                 logger.error(f"Error computing host galaxy correction for {result}: {e}")
 
     logger.info("Done.")
+
+
+def process_astrosource(args):
+    from iop4lib.db import ReducedFit, AstroSource, PhotoPolResult, Epoch
+    
+    astrosource = AstroSource.objects.get(name=args.astrosource)
+    qs_all = ReducedFit.objects.filter(epoch__night__gte=args.date_start, epoch__night__lte=args.date_end)
+
+    # filter files who have identified this source (in sources_in_field) or have this source as header_hintobject
+
+    redfL = list()
+    for redf in qs_all:
+        if redf.sources_in_field.filter(name=args.astrosource).exists() or redf.header_hintobject == astrosource:
+            redfL.append(redf)
+
+    logger.info(f"Found {len(redfL)} reduced fits for astrosource {args.astrosource}")
+
+    if args.force_rebuild:
+        logger.info("Forcing rebuild of reduced fits.")
+        Epoch.reduce_reducedfits(redfL)
+    
+    if args.retry_failed:
+        logger.info("Retrying failed reduced fits.")
+        redfL_failed = [redf for redf in redfL if redf.has_flag(ReducedFit.FLAGS.ERROR_ASTROMETRY)]
+        Epoch.reduce_reducedfits(redfL_failed)
+
+    if args.recompute:
+        qs_res = PhotoPolResult.objects.filter(reducedfits__in=redfL)
+        n_res_before = qs_res.count()
+
+        logger.info(f"Recomputing {n_res_before} results.")
+
+        deletion = qs_res.delete()
+
+        logger.info(f"Deleted: %s" % deletion)
+
+        for redf in redfL:
+            redf.compute_photometry()
+            redf.compute_polarimetry()
+
+        qs_res = PhotoPolResult.objects.filter(reducedfits__in=redfL)
+        n_res_after = qs_res.count()
+
+        logger.info(f"Recomputed {n_res_after} ({n_res_after-n_res_before} new).")
+
 
 
 def list_local_epochnames() -> list[str]:
@@ -277,13 +322,14 @@ def main():
     parser.add_argument('--list-local-files', action='store_true', help='<Optional> Discover local files to process them')
     parser.add_argument('--list-files-only', action='store_true', help='<Optional> If given, the built list of filelocs will be printed but not processed')
     parser.add_argument('--no-check-db-files',  dest='keep_files_in_db', action='store_true', help='<Optional> Process discovered files even if they existed in archive')
-    
 
+    # source processing options
+    parser.add_argument('--astrosource', dest='astrosource', type=str, default=None, help='<Optional> Select files only of this source')
+    parser.add_argument('--recompute', action='store_true', help='<Optional> Recompute photometry and polarimetry results')
+    
     # other options
     parser.add_argument('--skip-remote-file-list', action='store_true', help='<Optional> Skip remote file list check')
     parser.add_argument("--force-rebuild", action="store_true", help="<Optional> Force re-building of files (pass force_rebuild=True)")
-    parser.add_argument('--retry-failed', action='store_true', help='<Optional> Retry failed reduced fits')
-    parser.add_argument('--reclassify-rawfits', dest="reclassify_rawfits", action="store_true", help="<Optional> Re-classify rawfits")
 
     # range
     parser.add_argument('--date-start', '-s', type=str, default=None, help='<Optional> Start date (YYYY-MM-DD)')
@@ -375,7 +421,7 @@ def main():
         if len(epochnames_to_process) > 0:
             logger.info("Processing epochs.")
             epochnames_to_process, _ = list(zip(*sorted([(epochname, Epoch.epochname_to_tel_night(epochname)[1].strftime("%Y-%m-%d")) for epochname in epochnames_to_process], key=lambda x: x[1], reverse=True)))
-            process_epochs(epochnames_to_process, args.force_rebuild, check_remote_list=~args.skip_remote_file_list)
+            process_epochs(epochnames_to_process, args)
     else:
         logger.info("Invoked with --list-only!")
 
@@ -436,25 +482,11 @@ def main():
     else:
         logger.info("Invoked with --list-files-only")
 
-    # Classify rawfits if indicated
 
-    if args.reclassify_rawfits:
-        
-        logger.info("Classifying rawfits.")
+    # Astrosource
 
-        for epochname in epochnames_to_process:
-            epoch = Epoch.by_epochname(epochname)
-            for rawfit in epoch.rawfits.all():
-                rawfit.classify()
-
-        for fileloc in filelocs_to_process:
-            rawfit = RawFit.by_fileloc(fileloc)
-            rawfit.classify()
-
-    # Retry failed files if indicated
-
-    if args.retry_failed:
-        retry_failed_files()
+    if args.astrosource is not None:
+        process_astrosource(args)
 
     # Start interactive shell if indicated
 


### PR DESCRIPTION
Removes the not very useful `--retry-failed` and `--reclassify-rawfits`. Tasks like those are better done in custom scripts or in the interactive cli. They are hard to implement in a way that it is useful (you need to change the code to affect the result), they did not allow selecting a subset, etc.