### PR TITLE
Improve DIPOL quad matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.10.9", "3.11"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.10.9"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.10.9"]
+        python-version: ["3.10.9", "3.11"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/iop4lib/instruments/dipol.py
+++ b/iop4lib/instruments/dipol.py
@@ -637,8 +637,8 @@ class DIPOL(Instrument):
             x, y = x[idx], y[idx]
             return 0.5*np.abs(np.dot(x,np.roll(y,1))-np.dot(y,np.roll(x,1)))
         
-        quads_1 = np.array([quad for quad in quads_1 if PolyArea(quad[:,0], quad[:,1]) > 0.05*(redf.width*redf.height)])
-        quads_2 = np.array([quad for quad in quads_2 if PolyArea(quad[:,0], quad[:,1]) > 0.05*(redf.width*redf.height)])
+        quads_1 = np.array([quad for quad in quads_1 if PolyArea(quad[:,0], quad[:,1]) > 0.05*(redf_pol.width*redf_pol.height)])
+        quads_2 = np.array([quad for quad in quads_2 if PolyArea(quad[:,0], quad[:,1]) > 0.05*(redf_pol.width*redf_pol.height)])
 
         if len(quads_1) == 0 or len(quads_2) == 0:
             logger.error(f"No quads found in {redf_pol} and {redf_phot}, returning success = False.")

--- a/iop4lib/instruments/dipol.py
+++ b/iop4lib/instruments/dipol.py
@@ -630,6 +630,16 @@ class DIPOL(Instrument):
         quads_1 = np.array(list(itertools.combinations(sets_L[0], 4)))
         quads_2 = np.array(list(itertools.combinations(sets_L[1], 4)))
 
+        # remove quads of points that have an area less than 5% of the image
+        def PolyArea(x,y):
+            # order points clockwise
+            idx = np.argsort(np.arctan2(y-y.mean(), x-x.mean()))
+            x, y = x[idx], y[idx]
+            return 0.5*np.abs(np.dot(x,np.roll(y,1))-np.dot(y,np.roll(x,1)))
+        
+        quads_1 = np.array([quad for quad in quads_1 if PolyArea(quad[:,0], quad[:,1]) > 0.05*(redf.width*redf.height)])
+        quads_2 = np.array([quad for quad in quads_2 if PolyArea(quad[:,0], quad[:,1]) > 0.05*(redf.width*redf.height)])
+
         if len(quads_1) == 0 or len(quads_2) == 0:
             logger.error(f"No quads found in {redf_pol} and {redf_phot}, returning success = False.")
             return BuildWCSResult(success=False)

--- a/iop4lib/instruments/dipol.py
+++ b/iop4lib/instruments/dipol.py
@@ -803,7 +803,7 @@ class DIPOL(Instrument):
             fig.clear()            
 
 
-        result = BuildWCSResult(success=True, wcslist=wcslist, info={'redf_phot__pk':redf_phot.pk, 'redf_phot__fileloc':redf_phot.fileloc, n_seg_threshold:n_seg_threshold, npixels:npixels})
+        result = BuildWCSResult(success=True, wcslist=wcslist, info={'redf_phot__pk':redf_phot.pk, 'redf_phot__fileloc':redf_phot.fileloc, 'n_seg_threshold':n_seg_threshold, 'npixels':npixels})
 
         return result
 


### PR DESCRIPTION
Improves DIPOL quad matching by requiring that matched quads cover a minimum area of the image.

This avoids quad matches that don't determine well the transformation between the images, and/or that happen to match fake sources very close to real sources.