### PR TITLE
Improve night summary script

### DIFF
--- a/docs/serving_iop4_in_production.rst
+++ b/docs/serving_iop4_in_production.rst
@@ -99,13 +99,17 @@ Then, create a file ``run_iop4_daily.sh``, give it execution permissions (``chmo
     # Run iop4 for new observations (i.e. last night)
     iop4 --discover-missing -o log_file=/home/vhega/iop4data/logs/daily_$date.log
 
-    # Create and send a summary of the results for last night
+    # save return code
+    rc=$?
+
+    # Create and send a summary of the results for last night, passing the return code
     iop4-night-summary  --fromaddr '{{YOUR SENDER ADDRESS}}' \
                         --mailto '{{ADDRESS 1}},{{ADDRESS 2}},{{ADDRESS 3}}' \
                         --contact-name '{{CONTACT NAME}}' \
                         --contact-email '{{CONTACT EMAIL}}' \
                         --site-url '{{DEPLOYMENT SITE URL}}' \
                         --saveto "/home/vhega/iop4data/logs/daily_$date.html"
+                        --rc $rc
 
 The above script will run iop4 every morning, disovering and proccessing new 
 observations. 

--- a/iop4lib/iop4_night_summary.html
+++ b/iop4lib/iop4_night_summary.html
@@ -39,6 +39,10 @@
 
         <hr/>
 
+        {% if argc.rc and args.rc != 0 %}
+            <p style="color:red;font-size:large;font-weight:bold;">the pipeline did not run properly (rc={{ args.rc }}) !</p>
+        {% endif %}
+
         <h2>Overview</h2>
         
         {% if epochs %}
@@ -70,7 +74,7 @@
                             <td>
                                 {% if epoch.files_with_error_astrometry %}
                                     <a href="{{ epoch.files_with_error_astrometry_href}}">
-                                        Err!
+                                        Err! ({{ epoch.files_with_error_astrometry|length }})
                                     </a>
                                 {% else %}
                                     OK

--- a/iop4lib/iop4_night_summary.html
+++ b/iop4lib/iop4_night_summary.html
@@ -39,7 +39,7 @@
 
         <hr/>
 
-        {% if argc.rc and args.rc != 0 %}
+        {% if args.rc and args.rc != 0 %}
             <p style="color:red;font-size:large;font-weight:bold;">the pipeline did not run properly (rc={{ args.rc }}) !</p>
         {% endif %}
 

--- a/iop4lib/iop4_night_summary.py
+++ b/iop4lib/iop4_night_summary.py
@@ -72,6 +72,10 @@ def gather_context(args):
         
     sources = AstroSource.objects.exclude(is_calibrator=True).filter(photopolresults__epoch__night=args.date).distinct()
 
+    if sources:
+        instruments = list([instrument.name for instrument in Instrument.get_known()])
+        colors = [mplt.colormaps['tab10'](i) for i in range(len(instruments))]
+
     results_summary_images = dict()
 
     for source in sources:
@@ -96,9 +100,6 @@ def gather_context(args):
 
         fig = mplt.figure.Figure(figsize=(800/100, 600/100), dpi=100)
         axs = fig.subplots(nrows=3, ncols=1, sharex=True, gridspec_kw={'hspace': 0.05})
-
-        instruments = list([instrument.name for instrument in Instrument.get_known()])
-        colors = [mplt.colormaps['tab10'](i) for i in range(len(instruments))]
 
         for instrument, color in zip(instruments, colors):
             qs = qs0.filter(instrument=instrument)

--- a/iop4lib/iop4_night_summary.py
+++ b/iop4lib/iop4_night_summary.py
@@ -14,6 +14,7 @@ from django.template import Context, Template
 
 # iop4lib imports
 from iop4lib.db import Epoch, RawFit, ReducedFit, PhotoPolResult, AstroSource
+from iop4lib.instruments import Instrument
 from iop4lib.enums import SRCTYPES
 from iop4lib.utils import get_column_values
 
@@ -96,11 +97,15 @@ def gather_context(args):
         fig = mplt.figure.Figure(figsize=(800/100, 600/100), dpi=100)
         axs = fig.subplots(nrows=3, ncols=1, sharex=True, gridspec_kw={'hspace': 0.05})
 
-        instruments = list(set(qs0.values_list('instrument', flat=True).distinct()))
+        instruments = list([instrument.name for instrument in Instrument.get_known()])
         colors = [mplt.colormaps['tab10'](i) for i in range(len(instruments))]
 
         for instrument, color in zip(instruments, colors):
             qs = qs0.filter(instrument=instrument)
+
+            if not qs.exists():
+                continue
+
             column_names = ['id', 'juliandate', 'band', 'instrument', 'mag', 'mag_err', 'p', 'p_err', 'chi', 'chi_err', 'flags']
             vals =  get_column_values(qs, column_names)
             vals['datetime'] = Time(vals['juliandate'], format='jd').datetime

--- a/iop4lib/iop4_night_summary.py
+++ b/iop4lib/iop4_night_summary.py
@@ -207,7 +207,7 @@ def main():
     argparser.add_argument('--contact-email', type=str, default=None, help='Email to indicate as contact (default is the sender address)')
     argparser.add_argument('--site-url', type=str, default="localhost:8000", help='URL of the site to link the summary')
     argparser.add_argument('--saveto', type=str, default=None, help='Save the summary to a file')
-    argparser.add_argument('--rc', type=int, default=None, help="Indicate the return code to warn the user if the script fails")
+    argparser.add_argument('--rc', type=int, default=None, help="Indicate the return code from IOP4 to warn the user if the data processing fails")
 
     args = argparser.parse_args()
 

--- a/iop4lib/iop4_night_summary.py
+++ b/iop4lib/iop4_night_summary.py
@@ -73,7 +73,7 @@ def gather_context(args):
     sources = AstroSource.objects.exclude(is_calibrator=True).filter(photopolresults__epoch__night=args.date).distinct()
 
     if sources:
-        instruments = list([instrument.name for instrument in Instrument.get_known()])
+        instruments = [instrument.name for instrument in Instrument.get_known()]
         colors = [mplt.colormaps['tab10'](i) for i in range(len(instruments))]
 
     results_summary_images = dict()

--- a/iop4lib/iop4_night_summary.py
+++ b/iop4lib/iop4_night_summary.py
@@ -206,6 +206,7 @@ def main():
     argparser.add_argument('--contact-email', type=str, default=None, help='Email to indicate as contact (default is the sender address)')
     argparser.add_argument('--site-url', type=str, default="localhost:8000", help='URL of the site to link the summary')
     argparser.add_argument('--saveto', type=str, default=None, help='Save the summary to a file')
+    argparser.add_argument('--rc', type=int, default=None, help="Indicate the return code to warn the user if the script fails")
 
     args = argparser.parse_args()
 


### PR DESCRIPTION
This PR improves the night summary script by:
 - using the same instrument color code in all plots. Previously, different plots in the same summary were choosing the colors independently, which was confusing when looking at the plots.
 - showing a warning if the specified return code of the iop4 command is not zero. Previously, a fatal error during the pipeline execution could result in the IOP4 script terminating prematurely and only some results showing in the summary script, without clear hints indicating that this happened.