### PR TITLE
Fix quad matching

### DIFF
--- a/iop4lib/utils/quadmatching.py
+++ b/iop4lib/utils/quadmatching.py
@@ -1,4 +1,4 @@
-from itertools import combinations
+import itertools
 import numpy as np
 
 def distance(h1,h2):
@@ -187,3 +187,43 @@ def find_linear_transformation(P1, P2):
     t = P2_mean - R @ P1_mean
     
     return R, t
+
+
+def distance_to_y_flip(R):
+    # Target matrix for a single Y-axis flip
+    R_target = np.array([[1, 0], [0, -1]])
+    
+    # Compute Frobenius norm of the difference
+    return np.linalg.norm(R - R_target)
+
+def find_best_transformation(P1, P2, distance_function):
+    P1, P2 = np.array(P1), np.array(P2)
+    
+    # Store all permutations and their corresponding transformations (R, t)
+    permutations = list(itertools.permutations(P2))
+    transformations = [find_linear_transformation(P1, perm) for perm in permutations]
+    
+    # Compute distances to the target transformation (using distance_function)
+    distances = [distance_function(R) for R, _ in transformations]
+    
+    # Find the permutation with the minimum distance
+    best_index = np.argmin(distances)
+    
+    best_R, best_t = transformations[best_index]
+    best_perm = permutations[best_index]
+    
+    return best_R, best_t, best_perm
+
+def distance_to_y_flip(R):
+    # Target matrix for a single Y-axis flip
+    R_target = np.array([[1, 0], [0, -1]])
+    
+    # Compute Frobenius norm of the difference
+    return np.linalg.norm(R - R_target)
+
+def distance_to_identity(R):
+    # Target matrix is the identity matrix
+    R_target = np.eye(2)  # Identity matrix of size 2x2
+    
+    # Compute Frobenius norm of the difference
+    return np.linalg.norm(R - R_target)

--- a/iop4lib/utils/quadmatching.py
+++ b/iop4lib/utils/quadmatching.py
@@ -197,6 +197,8 @@ def distance_to_y_flip(R):
     return np.linalg.norm(R - R_target)
 
 def find_best_transformation(P1, P2, distance_function):
+    """Find the linear transformation of P1 to P2 that minimizes the distance function, searching over all permutations of P2."""
+
     P1, P2 = np.array(P1), np.array(P2)
     
     # Store all permutations and their corresponding transformations (R, t)


### PR DESCRIPTION
The quad hash is purposely invariant to flips and permutations. This results sometimes in a bad mapping from the sources in the photometry field and the ones in the polarimetry field. This can be observed in these two images of the same source, where one is correctly mapped, and the other one is not.

ReducedFit 242884
OSN-T090/2024-10-23/J0211_R_IAR-0371_DIPOL.fts

<img src="https://github.com/user-attachments/assets/f438e5ef-7c9c-49b1-ba1a-9b175a24a0c4" width="300">
<img src="https://github.com/user-attachments/assets/ececc1c9-bede-4bc6-8188-ed44e93a8e43" width="300">

ReducedFit 242883
OSN-T090/2024-10-23/J0211_R_IAR-0370_DIPOL.fts

<img src="https://github.com/user-attachments/assets/7fcf493c-198b-478d-983f-ed2732a9c59d" width="300">
<img src="https://github.com/user-attachments/assets/b8be3e92-7ebf-43b8-8aa0-cffc52fc23ff" width="300">

To resolve this ambiguity, this PR introduces a check of the flip status (sometimes introduced by MaximDL during data taking) and finds the linear transform that correctly takes into account this possible flip.

The new procedure correctly identifies the target source in both images above, both of which have a flip present. It also correctly identifies the source in images where no flip is present:

ReducedFit 242959
OSN-T090/2024-10-23/J0217_R_IAR-0074_DIPOL.fts

<img src="https://github.com/user-attachments/assets/f2083121-305a-4405-a7d6-e9231f0591c3" width="300">
<img src="https://github.com/user-attachments/assets/7b7fa05d-abc5-4237-802d-f82a9c93e611" width="300">
