### PR TITLE
Link to plot web gui in summary, fix plot

### DIFF
--- a/iop4lib/iop4_night_summary.html
+++ b/iop4lib/iop4_night_summary.html
@@ -3,6 +3,15 @@
         <title>iop4 summary {{night|date:"Y/m/d"}}</title>
     </head>
     <style>
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-size: 14px;
+        }
+
         table {
             border-collapse: collapse;
             width: 100%;
@@ -25,6 +34,13 @@
         hr {
             border: 1px solid black;
             margin: 1em 0;
+        }
+
+        img.source-plot {
+            min-width: 45em;
+            width: 49%;
+            max-width: 49%;
+            height: auto;
         }
 
     </style>
@@ -102,10 +118,17 @@
                 </p>
             {% endif %}
 
-            <p>Some of these plots might include the previous existing night for the source for comparison.</p>
+            <p>
+                <small>
+                    Some of these plots might include the previous existing night for the source for comparison. 
+                    Click on the plots to go to the interactive plot in the web interface.
+                </small>
+            </p>
 
-            {% for srcname, imgb64 in results_summary_images.items %}
-                <img src="data:image/png;base64,{{ imgb64 }}" alt="{{ srcname }}"/>
+            {% for srcname, val in results_summary_images.items %}
+                <a href="{{ val.source_plot_url}}">
+                    <img class="source-plot" src="data:image/png;base64,{{ val.imgb64 }}" alt="{{ srcname }}"/>
+                </a>
             {% endfor %}
 
         {% else %}

--- a/iop4lib/iop4_night_summary.py
+++ b/iop4lib/iop4_night_summary.py
@@ -31,6 +31,7 @@ import matplotlib as mplt
 import matplotlib.pyplot as plt
 from astropy.time import Time
 import smtplib, email
+from urllib.parse import urlencode, quote_plus
 
 # logging
 import coloredlogs, logging
@@ -91,17 +92,20 @@ def gather_context(args):
                       .filter(astrosource=source, band="R", epoch__night__lt=args.date)
                       .order_by('-epoch__night')
                       .values_list('epoch__night', flat=True)
-                      .last())
+                      .first())
 
-        # get the results for this source from the previous night, or for this night if there is no previous night
+        # Get the results for the source in the given night, but if there is only
+        # one result, get the results from the previous night for comparison
 
-        if prev_night is not None:
-            qs0 = PhotoPolResult.objects.filter(astrosource=source, band="R").filter(epoch__night__gte=args.date).order_by('-juliandate')
+        qs_today = PhotoPolResult.objects.filter(astrosource=source, band="R").filter(epoch__night=args.date)
+
+        if prev_night is not None and qs_today.count() == 1:
+            qs0 = PhotoPolResult.objects.filter(astrosource=source, band="R").filter(epoch__night__gte=prev_night, epoch__night__lte=args.date).order_by('-juliandate')
         else:
-            qs0 = PhotoPolResult.objects.filter(astrosource=source, band="R").filter(epoch__night=args.date).order_by('-juliandate')
+            qs0 = qs_today.order_by('-juliandate')
 
 
-        fig = mplt.figure.Figure(figsize=(800/100, 600/100), dpi=100)
+        fig = mplt.figure.Figure(figsize=(1000/100, 600/100), dpi=100)
         axs = fig.subplots(nrows=3, ncols=1, sharex=True, gridspec_kw={'hspace': 0.05})
 
         for instrument, color in zip(instruments, colors):
@@ -117,6 +121,10 @@ def gather_context(args):
             axs[0].errorbar(x=vals['datetime'], y=vals['mag'], yerr=vals['mag_err'], marker=".", color=color, linestyle="none")
             axs[1].errorbar(x=vals['datetime'], y=vals['p'], yerr=vals['p_err'], marker=".", color=color, linestyle="none")
             axs[2].errorbar(x=vals['datetime'], y=vals['chi'], yerr=vals['chi_err'], marker=".", color=color, linestyle="none")
+
+        # x-axis date locator and formatter
+        from matplotlib.dates import AutoDateLocator
+        axs[-1].xaxis.set_major_locator(AutoDateLocator(interval_multiples=False, maxticks=7))
 
         # invert magnitude axis
         axs[0].invert_yaxis()
@@ -156,7 +164,24 @@ def gather_context(args):
         imgbytes = buf.read()
         imgb64 = base64.b64encode(imgbytes).decode("utf-8")
 
-        results_summary_images[source.name] = imgb64
+        # build the link to the interactive source plot
+
+        url_args = dict()
+
+        url_args['srcname'] = source.name
+
+        if prev_night is not None:
+            url_args['from'] = str(prev_night)
+
+        # we need 12:00 of the next day
+        next_day_noon = (datetime.datetime.combine(args.date, datetime.time(12, 0)) + datetime.timedelta(days=1))
+        url_args['to'] = str(next_day_noon)
+
+        source_plot_url = args.site_url + "/iop4/explore/plot/?" + urlencode(url_args, quote_via=quote_plus)
+
+        # save the results to the context
+
+        results_summary_images[source.name] = dict(imgb64=imgb64, source_plot_url=source_plot_url)
 
     # save vars to context and return it
     


### PR DESCRIPTION
This PR improves the night summary by:
- Making the plots in the night summary clickable, linking to the interactive plot in the web gui.
- Fixing the plotting of previous night results. Results from the previous night, if available, are now plotted when the new night has only one point, to allow a comparison.
- Improves the style.