### PR TITLE
fix(tests): update VHEGA IOP4 site URL

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,7 +24,7 @@ identifiers:
   - type: doi
     value: 10.5281/zenodo.10222722
 repository-code: 'https://github.com/juanep97/iop4'
-url: 'https://vhega.iaa.es/iop4/about/'
+url: 'https://iop4.iaa.es/iop4/about/'
 abstract: IOP4, the Interactive Optical Photo-Polarimetric Python Pipeline.
 keywords:
   - astronomy

--- a/iop4api/templates/iop4api/index.html
+++ b/iop4api/templates/iop4api/index.html
@@ -46,13 +46,13 @@
 
         <div id="navbar">
             <div id="site-header">
-                <h1><a href="https://vhega.iaa.es/iop4">IOP4</a></h1>
-                <div>
-                    <h2><a href="https://vhega.iaa.es/">VHEGA@IAA-CSIC</a></h2>
+                <h1><a href="https://iop4.iaa.es/iop4">IOP4</a></h1>
+                <!-- <div>
+                    <h2><a href="https://iop4.iaa.es/">VHEGA@IAA-CSIC</a></h2>
                     {% if debug and request.user.is_authenticated %}
                         <span style="color: red;">DEBUG*</span>
                     {% endif %}
-                </div>
+                </div> -->
             </div>
             
             <q-tabs v-model="selectedTabs[0]" class="tab-navigator" id="site-nav" inline-label outside-arrows >

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def setUpClass():
     if not os.path.exists(TESTDATA_FPATH):
         print("Downloading test dataset")
         import requests
-        with requests.get(f"https://vhega.iaa.es/iop4/testdata/{Path(TESTDATA_FPATH).name}", stream=True) as r:
+        with requests.get(f"https://iop4.iaa.es/iop4/testdata/{Path(TESTDATA_FPATH).name}", stream=True) as r:
             r.raise_for_status()
             with open(TESTDATA_FPATH, 'wb') as f:
                 for chunk in r.iter_content(chunk_size=None):


### PR DESCRIPTION
Update VHEGA's IOP4 url after VHEGA@IAA-CSIC web site migration. Needed for test dataset download.